### PR TITLE
namespaced Math/Stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+
+before_script:
+  - composer install --dev
+
+script: phpunit

--- a/PEAR/Math/Stats.php
+++ b/PEAR/Math/Stats.php
@@ -1,73 +1,10 @@
 <?php
-//
-// +----------------------------------------------------------------------+
-// | PHP Version 4                                                        |
-// +----------------------------------------------------------------------+
-// | Copyright (c) 1997-2003 The PHP Group                                |
-// +----------------------------------------------------------------------+
-// | This source file is subject to version 2.0 of the PHP license,       |
-// | that is bundled with this package in the file LICENSE, and is        |
-// | available at through the world-wide-web at                           |
-// | http://www.php.net/license/2_02.txt.                                 |
-// | If you did not receive a copy of the PHP license and are unable to   |
-// | obtain it through the world-wide-web, please send a note to          |
-// | license@php.net so we can mail you a copy immediately.               |
-// +----------------------------------------------------------------------+
-// | Authors: Jesus M. Castagnetto <jmcastagnetto@php.net>                |
-// +----------------------------------------------------------------------+
-//
-// $Id$
-//
-
-include_once 'PEAR.php';
+namespace PEAR\Math;
 
 /**
  * @package Math_Stats
+ * @author Jesus M. Castagnetto <jmcastagnetto@php.net>
  */
-
-// Constants for defining the statistics to calculate /*{{{*/
-/**
- * STATS_BASIC to generate the basic descriptive statistics
- */
-define('STATS_BASIC', 1);
-/**
- * STATS_FULL to generate also higher moments, mode, median, etc.
- */
-define('STATS_FULL', 2);
-/*}}}*/
-
-// Constants describing the data set format /*{{{*/
-/**
- * STATS_DATA_SIMPLE for an array of numeric values. This is the default.
- * e.g. $data = array(2,3,4,5,1,1,6);
- */
-define('STATS_DATA_SIMPLE', 0);
-/**
- * STATS_DATA_CUMMULATIVE for an associative array of frequency values,
- * where in each array entry, the index is the data point and the
- * value the count (frequency):
- * e.g. $data = array(3=>4, 2.3=>5, 1.25=>6, 0.5=>3)
- */
-define('STATS_DATA_CUMMULATIVE', 1);
-/*}}}*/
-
-// Constants defining how to handle nulls /*{{{*/
-/**
- * STATS_REJECT_NULL, reject data sets with null values. This is the default.
- * Any non-numeric value is considered a null in this context.
- */
-define('STATS_REJECT_NULL', -1);
-/**
- * STATS_IGNORE_NULL, ignore null values and prune them from the data.
- * Any non-numeric value is considered a null in this context.
- */
-define('STATS_IGNORE_NULL', -2);
-/**
- * STATS_USE_NULL_AS_ZERO, assign the value of 0 (zero) to null values.
- * Any non-numeric value is considered a null in this context.
- */
-define('STATS_USE_NULL_AS_ZERO', -3);
-/*}}}*/
 
 /**
  * A class to calculate descriptive statistics from a data set.
@@ -88,23 +25,22 @@ define('STATS_USE_NULL_AS_ZERO', -3);
  * Example of use:
  *
  * <pre>
- * include_once 'Math/Stats.php';
- * $s = new Math_Stats();
+ * $s = new \Math\Stats();
  * $s->setData($data1);
  * // or
- * // $s->setData($data2, STATS_DATA_CUMMULATIVE);
+ * // $s->setData($data2, self::STATS_DATA_CUMMULATIVE);
  * $stats = $s->calcBasic();
  * echo 'Mean: '.$stats['mean'].' StDev: '.$stats['stdev'].' <br />\n';
- * 
+ *
  * // using data with nulls
  * // first ignoring them:
  * $data3 = array(1.2, 'foo', 2.4, 3.1, 4.2, 3.2, null, 5.1, 6.2);
- * $s->setNullOption(STATS_IGNORE_NULL);
+ * $s->setNullOption(self::STATS_IGNORE_NULL);
  * $s->setData($data3);
  * $stats3 = $s->calcFull();
  *
  * // and then assuming nulls == 0
- * $s->setNullOption(STATS_USE_NULL_AS_ZERO);
+ * $s->setNullOption(self::STATS_USE_NULL_AS_ZERO);
  * $s->setData($data3);
  * $stats3 = $s->calcFull();
  * </pre>
@@ -116,9 +52,52 @@ define('STATS_USE_NULL_AS_ZERO', -3);
  * @access  public
  * @package Math_Stats
  */
-class Math_Stats {/*{{{*/
-    // properties /*{{{*/
-    
+class Stats
+{
+
+// Constants for defining the statistics to calculate
+    /**
+     * STATS_BASIC to generate the basic descriptive statistics
+     */
+    const STATS_BASIC = 1;
+/**
+ * STATS_FULL to generate also higher moments, mode, median, etc.
+ */
+    const STATS_FULL = 2;
+
+// Constants describing the data set format
+    /**
+     * STATS_DATA_SIMPLE for an array of numeric values. This is the default.
+     * e.g. $data = array(2,3,4,5,1,1,6);
+     */
+    const STATS_DATA_SIMPLE = 0;
+/**
+ * STATS_DATA_CUMMULATIVE for an associative array of frequency values,
+ * where in each array entry, the index is the data point and the
+ * value the count (frequency):
+ * e.g. $data = array(3=>4, 2.3=>5, 1.25=>6, 0.5=>3)
+ */
+    const STATS_DATA_CUMMULATIVE = 1;
+
+// Constants defining how to handle nulls
+    /**
+     * STATS_REJECT_NULL, reject data sets with null values. This is the default.
+     * Any non-numeric value is considered a null in this context.
+     */
+    const STATS_REJECT_NULL = -1;
+/**
+ * STATS_IGNORE_NULL, ignore null values and prune them from the data.
+ * Any non-numeric value is considered a null in this context.
+ */
+    const STATS_IGNORE_NULL = -2;
+/**
+ * STATS_USE_NULL_AS_ZERO, assign the value of 0 (zero) to null values.
+ * Any non-numeric value is considered a null in this context.
+ */
+    const STATS_USE_NULL_AS_ZERO = -3;
+
+    // properties
+
     /**
      * The simple or cummulative data set.
      * Null by default.
@@ -126,7 +105,7 @@ class Math_Stats {/*{{{*/
      * @access  private
      * @var array
      */
-    var $_data = null;
+    private $_data = null;
 
     /**
      * Expanded data set. Only set when cummulative data
@@ -135,7 +114,7 @@ class Math_Stats {/*{{{*/
      * @access  private
      * @var array
      */
-    var $_dataExpanded = null;
+    private $_dataExpanded = null;
 
     /**
      * Flag for data type, one of STATS_DATA_SIMPLE or
@@ -144,7 +123,7 @@ class Math_Stats {/*{{{*/
      * @access  private
      * @var int
      */
-    var $_dataOption = null;
+    private $_dataOption = null;
 
     /**
      * Flag for null handling options. One of STATS_REJECT_NULL,
@@ -153,7 +132,7 @@ class Math_Stats {/*{{{*/
      * @access  private
      * @var int
      */
-    var $_nullOption;
+    private $_nullOption;
 
     /**
      * Array for caching result values, should be reset
@@ -162,10 +141,8 @@ class Math_Stats {/*{{{*/
      * @access private
      * @var array
      */
-    var $_calculatedValues = array();
+    private $_calculatedValues = array();
 
-    /*}}}*/
-    
     /**
      * Constructor for the class
      *
@@ -173,9 +150,11 @@ class Math_Stats {/*{{{*/
      * @param   optional    int $nullOption how to handle null values
      * @return  object  Math_Stats
      */
-    function Math_Stats($nullOption=STATS_REJECT_NULL) {/*{{{*/
+    public function __construct($nullOption = self::STATS_REJECT_NULL)
+    {
+
         $this->_nullOption = $nullOption;
-    }/*}}}*/
+    }
 
     /**
      * Sets and verifies the data, checking for nulls and using
@@ -186,24 +165,26 @@ class Math_Stats {/*{{{*/
      * @param   optional    int $opt    data format: STATS_DATA_CUMMULATIVE or STATS_DATA_SIMPLE (default)
      * @return  mixed   true on success, a PEAR_Error object otherwise
      */
-    function setData($arr, $opt=STATS_DATA_SIMPLE) {/*{{{*/
+    public function setData($arr, $opt = self::STATS_DATA_SIMPLE)
+    {
+
         if (!is_array($arr)) {
-            return PEAR::raiseError('invalid data, an array of numeric data was expected');
+            throw new \PEAR_Exception('invalid data, an array of numeric data was expected');
         }
         $this->_data = null;
         $this->_dataExpanded = null;
         $this->_dataOption = null;
         $this->_calculatedValues = array();
-        if ($opt == STATS_DATA_SIMPLE) {
+        if ($opt == self::STATS_DATA_SIMPLE) {
             $this->_dataOption = $opt;
             $this->_data = array_values($arr);
-        } else if ($opt == STATS_DATA_CUMMULATIVE) {
+        } else if ($opt == self::STATS_DATA_CUMMULATIVE) {
             $this->_dataOption = $opt;
             $this->_data = $arr;
             $this->_dataExpanded = array();
-        } 
+        }
         return $this->_validate();
-    }/*}}}*/
+    }
 
     /**
      * Returns the data which might have been modified
@@ -214,36 +195,40 @@ class Math_Stats {/*{{{*/
      * @return  mixed   array of data on success, a PEAR_Error object otherwise
      * @see _validate()
      */
-    function getData($expanded=false) {/*{{{*/
+    public function getData($expanded = false)
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
-        if ($this->_dataOption == STATS_DATA_CUMMULATIVE && $expanded) {
+        if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE && $expanded) {
             return $this->_dataExpanded;
         } else {
             return $this->_data;
         }
-    }/*}}}*/
+    }
 
     /**
      * Sets the null handling option.
      * Must be called before assigning a new data set containing null values
-     * 
+     *
      * @access  public
      * @return  mixed   true on success, a PEAR_Error object otherwise
      * @see _validate()
      */
-    function setNullOption($nullOption) {/*{{{*/
-        if ($nullOption == STATS_REJECT_NULL
-            || $nullOption == STATS_IGNORE_NULL
-            || $nullOption == STATS_USE_NULL_AS_ZERO) {
+    public function setNullOption($nullOption)
+    {
+
+        if ($nullOption == self::STATS_REJECT_NULL
+            || $nullOption == self::STATS_IGNORE_NULL
+            || $nullOption == self::STATS_USE_NULL_AS_ZERO) {
             $this->_nullOption = $nullOption;
             return true;
         } else {
-            return PEAR::raiseError('invalid null handling option expecting: '.
-                        'STATS_REJECT_NULL, STATS_IGNORE_NULL or STATS_USE_NULL_AS_ZERO');
+            throw new \PEAR_Exception('invalid null handling option expecting: ' .
+                'STATS_REJECT_NULL, STATS_IGNORE_NULL or STATS_USE_NULL_AS_ZERO');
         }
-    }/*}}}*/
+    }
 
     /**
      * Transforms the data by substracting each entry from the mean and
@@ -256,21 +241,25 @@ class Math_Stats {/*{{{*/
      * @see stDev()
      * @see setData()
      */
-    function studentize() {/*{{{*/
-        $mean = $this->mean();
-        if (PEAR::isError($mean)) {
+    public function studentize()
+    {
+
+        try {
+            $mean = $this->mean();
+        } catch (\PEAR_Exception $e) {
             return $mean;
         }
-        $std = $this->stDev();
-        if (PEAR::isError($std)) {
+        try {
+            $std = $this->stDev();
+        } catch (\PEAR_Exception $e) {
             return $std;
         }
         if ($std == 0) {
-            return PEAR::raiseError('cannot studentize data, standard deviation is zero.');
+            throw new \PEAR_Exception('cannot studentize data, standard deviation is zero.');
         }
-        $arr  = array();
-        if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
-            foreach ($this->_data as $val=>$freq) {
+        $arr = array();
+        if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
+            foreach ($this->_data as $val => $freq) {
                 $newval = ($val - $mean) / $std;
                 $arr["$newval"] = $freq;
             }
@@ -281,7 +270,7 @@ class Math_Stats {/*{{{*/
             }
         }
         return $this->setData($arr, $this->_dataOption);
-    }/*}}}*/
+    }
 
     /**
      * Transforms the data by substracting each entry from the mean.
@@ -292,14 +281,17 @@ class Math_Stats {/*{{{*/
      * @see mean()
      * @see setData()
      */
-    function center() {/*{{{*/
-        $mean = $this->mean();
-        if (PEAR::isError($mean)) {
+    public function center()
+    {
+
+        try {
+            $mean = $this->mean();
+        } catch (\PEAR_Exception $e) {
             return $mean;
         }
-        $arr  = array();
-        if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
-            foreach ($this->_data as $val=>$freq) {
+        $arr = array();
+        if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
+            foreach ($this->_data as $val => $freq) {
                 $newval = $val - $mean;
                 $arr["$newval"] = $freq;
             }
@@ -310,110 +302,118 @@ class Math_Stats {/*{{{*/
             }
         }
         return $this->setData($arr, $this->_dataOption);
-    }/*}}}*/
-       
+    }
+
     /**
      * Calculates the basic or full statistics for the data set
-     * 
+     *
      * @access  public
      * @param   int $mode   one of STATS_BASIC or STATS_FULL
-     * @param boolean $returnErrorObject whether the raw PEAR_Error (when true, default), 
+     * @param boolean $returnErrorObject whether the raw PEAR_Error (when true, default),
      *                  or only the error message will be returned (when false), if an error happens.
      * @return  mixed   an associative array of statistics on success, a PEAR_Error object otherwise
      * @see calcBasic()
      * @see calcFull()
-     */ 
-    function calc($mode, $returnErrorObject=true) {/*{{{*/
+     */
+    public function calc($mode, $returnErrorObject = true)
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
-        if ($mode == STATS_BASIC) {
+
+        if ($mode == self::STATS_BASIC) {
+
             return $this->calcBasic($returnErrorObject);
-        } elseif ($mode == STATS_FULL) {
+        } elseif ($mode == self::STATS_FULL) {
             return $this->calcFull($returnErrorObject);
         } else {
-            return PEAR::raiseError('incorrect mode, expected STATS_BASIC or STATS_FULL');
+            throw new \PEAR_Exception('incorrect mode, expected STATS_BASIC or STATS_FULL');
         }
-    }/*}}}*/
+    }
 
     /**
      * Calculates a basic set of statistics
      *
      * @access  public
-     * @param boolean $returnErrorObject whether the raw PEAR_Error (when true, default), 
+     * @param boolean $returnErrorObject whether the raw PEAR_Error (when true, default),
      *                  or only the error message will be returned (when false), if an error happens.
      * @return  mixed   an associative array of statistics on success, a PEAR_Error object otherwise
      * @see calc()
      * @see calcFull()
      */
-    function calcBasic($returnErrorObject=true) {/*{{{*/
-            return array (
-                'min' => $this->__format($this->min(), $returnErrorObject),
-                'max' => $this->__format($this->max(), $returnErrorObject),
-                'sum' => $this->__format($this->sum(), $returnErrorObject),
-                'sum2' => $this->__format($this->sum2(), $returnErrorObject),
-                'count' => $this->__format($this->count(), $returnErrorObject),
-                'mean' => $this->__format($this->mean(), $returnErrorObject),
-                'stdev' => $this->__format($this->stDev(), $returnErrorObject),
-                'variance' => $this->__format($this->variance(), $returnErrorObject),
-                'range' => $this->__format($this->range(), $returnErrorObject)
-            );
-    }/*}}}*/
+    public function calcBasic($returnErrorObject = true)
+    {
+        return array(
+            'min' => $this->__format($this->min(), $returnErrorObject),
+            'max' => $this->__format($this->max(), $returnErrorObject),
+            'sum' => $this->__format($this->sum(), $returnErrorObject),
+            'sum2' => $this->__format($this->sum2(), $returnErrorObject),
+            'count' => $this->__format($this->count(), $returnErrorObject),
+            'mean' => $this->__format($this->mean(), $returnErrorObject),
+            'stdev' => $this->__format($this->stDev(), $returnErrorObject),
+            'variance' => $this->__format($this->variance(), $returnErrorObject),
+            'range' => $this->__format($this->range(), $returnErrorObject),
+        );
+
+    }
 
     /**
      * Calculates a full set of statistics
      *
      * @access  public
-     * @param boolean $returnErrorObject whether the raw PEAR_Error (when true, default), 
+     * @param boolean $returnErrorObject whether the raw PEAR_Error (when true, default),
      *                  or only the error message will be returned (when false), if an error happens.
      * @return  mixed   an associative array of statistics on success, a PEAR_Error object otherwise
      * @see calc()
      * @see calcBasic()
      */
-    function calcFull($returnErrorObject=true) {/*{{{*/
-            return array (
-                'min' => $this->__format($this->min(), $returnErrorObject),
-                'max' => $this->__format($this->max(), $returnErrorObject),
-                'sum' => $this->__format($this->sum(), $returnErrorObject),
-                'sum2' => $this->__format($this->sum2(), $returnErrorObject),
-                'count' => $this->__format($this->count(), $returnErrorObject),
-                'mean' => $this->__format($this->mean(), $returnErrorObject),
-                'median' => $this->__format($this->median(), $returnErrorObject),
-                'mode' => $this->__format($this->mode(), $returnErrorObject),
-                'midrange' => $this->__format($this->midrange(), $returnErrorObject),
-                'geometric_mean' => $this->__format($this->geometricMean(), $returnErrorObject),
-                'harmonic_mean' => $this->__format($this->harmonicMean(), $returnErrorObject),
-                'stdev' => $this->__format($this->stDev(), $returnErrorObject),
-                'absdev' => $this->__format($this->absDev(), $returnErrorObject),
-                'variance' => $this->__format($this->variance(), $returnErrorObject),
-                'range' => $this->__format($this->range(), $returnErrorObject),
-                'std_error_of_mean' => $this->__format($this->stdErrorOfMean(), $returnErrorObject),
-                'skewness' => $this->__format($this->skewness(), $returnErrorObject),
-                'kurtosis' => $this->__format($this->kurtosis(), $returnErrorObject),
-                'coeff_of_variation' => $this->__format($this->coeffOfVariation(), $returnErrorObject),
-                'sample_central_moments' => array (
-                            1 => $this->__format($this->sampleCentralMoment(1), $returnErrorObject),
-                            2 => $this->__format($this->sampleCentralMoment(2), $returnErrorObject),
-                            3 => $this->__format($this->sampleCentralMoment(3), $returnErrorObject),
-                            4 => $this->__format($this->sampleCentralMoment(4), $returnErrorObject),
-                            5 => $this->__format($this->sampleCentralMoment(5), $returnErrorObject)
-                            ),
-                'sample_raw_moments' => array (
-                            1 => $this->__format($this->sampleRawMoment(1), $returnErrorObject),
-                            2 => $this->__format($this->sampleRawMoment(2), $returnErrorObject),
-                            3 => $this->__format($this->sampleRawMoment(3), $returnErrorObject),
-                            4 => $this->__format($this->sampleRawMoment(4), $returnErrorObject),
-                            5 => $this->__format($this->sampleRawMoment(5), $returnErrorObject)
-                            ),
-                'frequency' => $this->__format($this->frequency(), $returnErrorObject),
-                'quartiles' => $this->__format($this->quartiles(), $returnErrorObject),
-                'interquartile_range' => $this->__format($this->interquartileRange(), $returnErrorObject),
-                'interquartile_mean' => $this->__format($this->interquartileMean(), $returnErrorObject),
-                'quartile_deviation' => $this->__format($this->quartileDeviation(), $returnErrorObject),
-                'quartile_variation_coefficient' => $this->__format($this->quartileVariationCoefficient(), $returnErrorObject),
-                'quartile_skewness_coefficient' => $this->__format($this->quartileSkewnessCoefficient(), $returnErrorObject)
-            );
-    }/*}}}*/
+    public function calcFull($returnErrorObject = true)
+    {
+
+        return array(
+            'min' => $this->__format($this->min(), $returnErrorObject),
+            'max' => $this->__format($this->max(), $returnErrorObject),
+            'sum' => $this->__format($this->sum(), $returnErrorObject),
+            'sum2' => $this->__format($this->sum2(), $returnErrorObject),
+            'count' => $this->__format($this->count(), $returnErrorObject),
+            'mean' => $this->__format($this->mean(), $returnErrorObject),
+            'median' => $this->__format($this->median(), $returnErrorObject),
+            'mode' => $this->__format($this->mode(), $returnErrorObject),
+            'midrange' => $this->__format($this->midrange(), $returnErrorObject),
+            'geometric_mean' => $this->__format($this->geometricMean(), $returnErrorObject),
+            'harmonic_mean' => $this->__format($this->harmonicMean(), $returnErrorObject),
+            'stdev' => $this->__format($this->stDev(), $returnErrorObject),
+            'absdev' => $this->__format($this->absDev(), $returnErrorObject),
+            'variance' => $this->__format($this->variance(), $returnErrorObject),
+            'range' => $this->__format($this->range(), $returnErrorObject),
+            'std_error_of_mean' => $this->__format($this->stdErrorOfMean(), $returnErrorObject),
+            'skewness' => $this->__format($this->skewness(), $returnErrorObject),
+            'kurtosis' => $this->__format($this->kurtosis(), $returnErrorObject),
+            'coeff_of_variation' => $this->__format($this->coeffOfVariation(), $returnErrorObject),
+            'sample_central_moments' => array(
+                1 => $this->__format($this->sampleCentralMoment(1), $returnErrorObject),
+                2 => $this->__format($this->sampleCentralMoment(2), $returnErrorObject),
+                3 => $this->__format($this->sampleCentralMoment(3), $returnErrorObject),
+                4 => $this->__format($this->sampleCentralMoment(4), $returnErrorObject),
+                5 => $this->__format($this->sampleCentralMoment(5), $returnErrorObject),
+            ),
+            'sample_raw_moments' => array(
+                1 => $this->__format($this->sampleRawMoment(1), $returnErrorObject),
+                2 => $this->__format($this->sampleRawMoment(2), $returnErrorObject),
+                3 => $this->__format($this->sampleRawMoment(3), $returnErrorObject),
+                4 => $this->__format($this->sampleRawMoment(4), $returnErrorObject),
+                5 => $this->__format($this->sampleRawMoment(5), $returnErrorObject),
+            ),
+            'frequency' => $this->__format($this->frequency(), $returnErrorObject),
+            'quartiles' => $this->__format($this->quartiles(), $returnErrorObject),
+            'interquartile_range' => $this->__format($this->interquartileRange(), $returnErrorObject),
+            'interquartile_mean' => $this->__format($this->interquartileMean(), $returnErrorObject),
+            'quartile_deviation' => $this->__format($this->quartileDeviation(), $returnErrorObject),
+            'quartile_variation_coefficient' => $this->__format($this->quartileVariationCoefficient(), $returnErrorObject),
+            'quartile_skewness_coefficient' => $this->__format($this->quartileSkewnessCoefficient(), $returnErrorObject),
+        );
+    }
 
     /**
      * Calculates the minimum of a data set.
@@ -424,20 +424,25 @@ class Math_Stats {/*{{{*/
      * @see calc()
      * @see max()
      */
-    function min() {/*{{{*/
+    public function min()
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
+
         if (!array_key_exists('min', $this->_calculatedValues)) {
-            if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
+            if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
                 $min = min(array_keys($this->_data));
             } else {
                 $min = min($this->_data);
             }
+
             $this->_calculatedValues['min'] = $min;
         }
+
         return $this->_calculatedValues['min'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the maximum of a data set.
@@ -448,12 +453,14 @@ class Math_Stats {/*{{{*/
      * @see calc()
      * @see min()
      */
-    function max() {/*{{{*/
+    public function max()
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         if (!array_key_exists('max', $this->_calculatedValues)) {
-            if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
+            if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
                 $max = max(array_keys($this->_data));
             } else {
                 $max = max($this->_data);
@@ -461,51 +468,56 @@ class Math_Stats {/*{{{*/
             $this->_calculatedValues['max'] = $max;
         }
         return $this->_calculatedValues['max'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates SUM { xi }
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the sum on success, a PEAR_Error object otherwise   
+     * @return  mixed   the sum on success, a PEAR_Error object otherwise
      * @see calc()
      * @see sum2()
      * @see sumN()
      */
-    function sum() {/*{{{*/
+    public function sum()
+    {
+
         if (!array_key_exists('sum', $this->_calculatedValues)) {
-            $sum = $this->sumN(1);
-            if (PEAR::isError($sum)) {
-                return $sum;
-            } else {
+            try {
+                $sum = $this->sumN(1);
                 $this->_calculatedValues['sum'] = $sum;
+            } catch (\PEAR_Exception $e) {
+                return $sum;
             }
+
         }
         return $this->_calculatedValues['sum'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates SUM { (xi)^2 }
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the sum on success, a PEAR_Error object otherwise   
+     * @return  mixed   the sum on success, a PEAR_Error object otherwise
      * @see calc()
      * @see sum()
      * @see sumN()
      */
-    function sum2() {/*{{{*/
+    public function sum2()
+    {
+
         if (!array_key_exists('sum2', $this->_calculatedValues)) {
-            $sum2 = $this->sumN(2);
-            if (PEAR::isError($sum2)) {
-                return $sum2;
-            } else {
+            try {
+                $sum2 = $this->sumN(2);
                 $this->_calculatedValues['sum2'] = $sum2;
+            } catch (\PEAR_Exception $e) {
+                return $sum2;
             }
         }
         return $this->_calculatedValues['sum2'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates SUM { (xi)^n }
@@ -513,49 +525,54 @@ class Math_Stats {/*{{{*/
      *
      * @access  public
      * @param   numeric $n  the exponent
-     * @return  mixed   the sum on success, a PEAR_Error object otherwise   
+     * @return  mixed   the sum on success, a PEAR_Error object otherwise
      * @see calc()
      * @see sum()
      * @see sum2()
      */
-    function sumN($n) {/*{{{*/
+    public function sumN($n)
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         $sumN = 0;
-        if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
-            foreach($this->_data as $val=>$freq) {
-                $sumN += $freq * pow((double)$val, (double)$n);
+        if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
+            foreach ($this->_data as $val => $freq) {
+                $sumN += $freq * pow((double) $val, (double) $n);
             }
         } else {
-            foreach($this->_data as $val) {
-                $sumN += pow((double)$val, (double)$n);
+            foreach ($this->_data as $val) {
+                $sumN += pow((double) $val, (double) $n);
             }
         }
         return $sumN;
-    }/*}}}*/
+    }
 
     /**
      * Calculates PROD { (xi) }, (the product of all observations)
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  numeric|array|PEAR_Error  the product as a number or an array of numbers 
-     *                                    (if there is numeric overflow) on success, 
-     *                                    a PEAR_Error object otherwise   
+     * @return  numeric|array|PEAR_Error  the product as a number or an array of numbers
+     *                                    (if there is numeric overflow) on success,
+     *                                    a PEAR_Error object otherwise
      * @see productN()
      */
-    function product() {/*{{{*/
+    public function product()
+    {
+
         if (!array_key_exists('product', $this->_calculatedValues)) {
-            $product = $this->productN(1);
-            if (PEAR::isError($product)) {
-                return $product;
-            } else {
+            try {
+                $product = $this->productN(1);
                 $this->_calculatedValues['product'] = $product;
+            } catch (\PEAR_Exception $e) {
+                return $product;
             }
+
         }
         return $this->_calculatedValues['product'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates PROD { (xi)^n }, which is the product of all observations
@@ -563,35 +580,37 @@ class Math_Stats {/*{{{*/
      *
      * @access  public
      * @param   numeric $n  the exponent
-     * @return  numeric|array|PEAR_Error  the product as a number or an array of numbers 
-     *                                    (if there is numeric overflow) on success, 
-     *                                    a PEAR_Error object otherwise   
+     * @return  numeric|array|PEAR_Error  the product as a number or an array of numbers
+     *                                    (if there is numeric overflow) on success,
+     *                                    a PEAR_Error object otherwise
      * @see product()
      */
-    function productN($n) {/*{{{*/
+    public function productN($n)
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         $prodN = 1.0;
         $partial = array();
-        if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
-            foreach($this->_data as $val=>$freq) {
+        if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
+            foreach ($this->_data as $val => $freq) {
                 if ($val == 0) {
                     return 0.0;
                 }
-                $prodN *= $freq * pow((double)$val, (double)$n);
-                if ($prodN > 10000*$n) {
+                $prodN *= $freq * pow((double) $val, (double) $n);
+                if ($prodN > 10000 * $n) {
                     $partial[] = $prodN;
                     $prodN = 1.0;
                 }
             }
         } else {
-            foreach($this->_data as $val) {
+            foreach ($this->_data as $val) {
                 if ($val == 0) {
                     return 0.0;
                 }
-                $prodN *= pow((double)$val, (double)$n);
-                if ($prodN > 10*$n) {
+                $prodN *= pow((double) $val, (double) $n);
+                if ($prodN > 10 * $n) {
                     $partial[] = $prodN;
                     $prodN = 1.0;
                 }
@@ -613,22 +632,24 @@ class Math_Stats {/*{{{*/
             return $prodN;
         }
 
-    }/*}}}*/
+    }
 
     /**
      * Calculates the number of data points in the set
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the count on success, a PEAR_Error object otherwise 
+     * @return  mixed   the count on success, a PEAR_Error object otherwise
      * @see calc()
      */
-    function count() {/*{{{*/
+    public function count()
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         if (!array_key_exists('count', $this->_calculatedValues)) {
-            if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
+            if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
                 $count = count($this->_dataExpanded);
             } else {
                 $count = count($this->_data);
@@ -636,32 +657,37 @@ class Math_Stats {/*{{{*/
             $this->_calculatedValues['count'] = $count;
         }
         return $this->_calculatedValues['count'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the mean (average) of the data points in the set
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the mean value on success, a PEAR_Error object otherwise    
+     * @return  mixed   the mean value on success, a PEAR_Error object otherwise
      * @see calc()
      * @see sum()
      * @see count()
      */
-    function mean() {/*{{{*/
+    public function mean()
+    {
+
         if (!array_key_exists('mean', $this->_calculatedValues)) {
-            $sum = $this->sum();
-            if (PEAR::isError($sum)) {
+            try {
+                $sum = $this->sum();
+                try {
+                    $count = $this->count();
+                } catch (\PEAR_Exception $e) {
+                    return $count;
+                }
+                $this->_calculatedValues['mean'] = $sum / $count;
+            } catch (\PEAR_Exception $e) {
                 return $sum;
             }
-            $count = $this->count();
-            if (PEAR::isError($count)) {
-                return $count;
-            }
-            $this->_calculatedValues['mean'] = $sum / $count;
+
         }
         return $this->_calculatedValues['mean'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the range of the data set = max - min
@@ -669,62 +695,76 @@ class Math_Stats {/*{{{*/
      * @access public
      * @return mixed the value of the range on success, a PEAR_Error object otherwise.
      */
-    function range() {/*{{{*/
+    public function range()
+    {
+
         if (!array_key_exists('range', $this->_calculatedValues)) {
-            $min = $this->min();
-            if (PEAR::isError($min)) {
+            try {
+                $min = $this->min();
+                try {
+                    $max = $this->max();
+                } catch (\PEAR_Exception $e) {
+                    return $max;
+                }
+                $this->_calculatedValues['range'] = $max - $min;
+
+            } catch (\PEAR_Exception $e) {
                 return $min;
             }
-            $max = $this->max();
-            if (PEAR::isError($max)) {
-                return $max;
-            }
-            $this->_calculatedValues['range'] = $max - $min;
+
         }
         return $this->_calculatedValues['range'];
 
-    }/*}}}*/
+    }
 
     /**
      * Calculates the variance (unbiased) of the data points in the set
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the variance value on success, a PEAR_Error object otherwise    
+     * @return  mixed   the variance value on success, a PEAR_Error object otherwise
      * @see calc()
      * @see __sumdiff()
      * @see count()
      */
-    function variance() {/*{{{*/
+    public function variance()
+    {
+
         if (!array_key_exists('variance', $this->_calculatedValues)) {
-            $variance = $this->__calcVariance();
-            if (PEAR::isError($variance)) {
+            try {
+                $variance = $this->__calcVariance();
+            } catch (\PEAR_Exception $e) {
                 return $variance;
             }
+
             $this->_calculatedValues['variance'] = $variance;
         }
         return $this->_calculatedValues['variance'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the standard deviation (unbiased) of the data points in the set
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the standard deviation on success, a PEAR_Error object otherwise    
+     * @return  mixed   the standard deviation on success, a PEAR_Error object otherwise
      * @see calc()
      * @see variance()
      */
-    function stDev() {/*{{{*/
+    public function stDev()
+    {
+
         if (!array_key_exists('stDev', $this->_calculatedValues)) {
-            $variance = $this->variance();
-            if (PEAR::isError($variance)) {
+            try {
+                $variance = $this->variance();
+            } catch (\PEAR_Exception $e) {
                 return $variance;
             }
+
             $this->_calculatedValues['stDev'] = sqrt($variance);
         }
         return $this->_calculatedValues['stDev'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the variance (unbiased) of the data points in the set
@@ -734,15 +774,17 @@ class Math_Stats {/*{{{*/
      *
      * @access  public
      * @param   numeric $mean   the fixed mean value
-     * @return  mixed   the variance on success, a PEAR_Error object otherwise  
+     * @return  mixed   the variance on success, a PEAR_Error object otherwise
      * @see __sumdiff()
      * @see count()
      * @see variance()
      */
-    function varianceWithMean($mean) {/*{{{*/
+    public function varianceWithMean($mean)
+    {
+
         return $this->__calcVariance($mean);
-    }/*}}}*/
-    
+    }
+
     /**
      * Calculates the standard deviation (unbiased) of the data points in the set
      * given a fixed mean (average) value. Not used in calcBasic(), calcFull()
@@ -751,39 +793,46 @@ class Math_Stats {/*{{{*/
      *
      * @access  public
      * @param   numeric $mean   the fixed mean value
-     * @return  mixed   the standard deviation on success, a PEAR_Error object otherwise    
+     * @return  mixed   the standard deviation on success, a PEAR_Error object otherwise
      * @see varianceWithMean()
      * @see stDev()
      */
-    function stDevWithMean($mean) {/*{{{*/
-        $varianceWM = $this->varianceWithMean($mean);
-        if (PEAR::isError($varianceWM)) {
+    public function stDevWithMean($mean)
+    {
+        try {
+            $varianceWM = $this->varianceWithMean($mean);
+        } catch (\PEAR_Exception $e) {
             return $varianceWM;
         }
+
         return sqrt($varianceWM);
-    }/*}}}*/
+    }
 
     /**
      * Calculates the absolute deviation of the data points in the set
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the absolute deviation on success, a PEAR_Error object otherwise    
+     * @return  mixed   the absolute deviation on success, a PEAR_Error object otherwise
      * @see calc()
      * @see __sumabsdev()
      * @see count()
      * @see absDevWithMean()
      */
-    function absDev() {/*{{{*/
+    public function absDev()
+    {
+
         if (!array_key_exists('absDev', $this->_calculatedValues)) {
-            $absDev = $this->__calcAbsoluteDeviation();
-            if (PEAR::isError($absDev)) {
+            try {
+                $absDev = $this->__calcAbsoluteDeviation();
+            } catch (\PEAR_Exception $e) {
                 return $absDev;
             }
+
             $this->_calculatedValues['absDev'] = $absDev;
         }
         return $this->_calculatedValues['absDev'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the absolute deviation of the data points in the set
@@ -793,13 +842,15 @@ class Math_Stats {/*{{{*/
      *
      * @access  public
      * @param   numeric $mean   the fixed mean value
-     * @return  mixed   the absolute deviation on success, a PEAR_Error object otherwise    
+     * @return  mixed   the absolute deviation on success, a PEAR_Error object otherwise
      * @see __sumabsdev()
      * @see absDev()
      */
-    function absDevWithMean($mean) {/*{{{*/
+    public function absDevWithMean($mean)
+    {
+
         return $this->__calcAbsoluteDeviation($mean);
-    }/*}}}*/
+    }
 
     /**
      * Calculates the skewness of the data distribution in the set
@@ -813,30 +864,36 @@ class Math_Stats {/*{{{*/
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the skewness value on success, a PEAR_Error object otherwise    
+     * @return  mixed   the skewness value on success, a PEAR_Error object otherwise
      * @see __sumdiff()
      * @see count()
      * @see stDev()
      * @see calc()
      */
-    function skewness() {/*{{{*/
+    public function skewness()
+    {
+
         if (!array_key_exists('skewness', $this->_calculatedValues)) {
-            $count = $this->count();
-            if (PEAR::isError($count)) {
+            try {
+                $count = $this->count();
+                try {
+                    $stDev = $this->stDev();
+                    try {
+                        $sumdiff3 = $this->__sumdiff(3);
+                    } catch (\PEAR_Exception $e) {
+                        return $sumdiff3;
+                    }
+                } catch (\PEAR_Exception $e) {
+                    return $stDev;
+                }
+            } catch (\PEAR_Exception $e) {
                 return $count;
             }
-            $stDev = $this->stDev();
-            if (PEAR::isError($stDev)) {
-                return $stDev;
-            }
-            $sumdiff3 = $this->__sumdiff(3);
-            if (PEAR::isError($sumdiff3)) {
-                return $sumdiff3;
-            }
+
             $this->_calculatedValues['skewness'] = ($sumdiff3 / ($count * pow($stDev, 3)));
         }
         return $this->_calculatedValues['skewness'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the kurtosis of the data distribution in the set
@@ -850,30 +907,37 @@ class Math_Stats {/*{{{*/
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the kurtosis value on success, a PEAR_Error object otherwise    
+     * @return  mixed   the kurtosis value on success, a PEAR_Error object otherwise
      * @see __sumdiff()
      * @see count()
      * @see stDev()
      * @see calc()
      */
-    function kurtosis() {/*{{{*/
+    public function kurtosis()
+    {
+
         if (!array_key_exists('kurtosis', $this->_calculatedValues)) {
-            $count = $this->count();
-            if (PEAR::isError($count)) {
+
+            try {
+                $count = $this->count();
+                try {
+                    $stDev = $this->stDev();
+                    try {
+                        $sumdiff4 = $this->__sumdiff(4);
+                    } catch (\PEAR_Exception $e) {
+                        return $sumdiff4;
+                    }
+                } catch (\PEAR_Exception $e) {
+                    return $stDev;
+                }
+            } catch (\PEAR_Exception $e) {
                 return $count;
             }
-            $stDev = $this->stDev();
-            if (PEAR::isError($stDev)) {
-                return $stDev;
-            }
-            $sumdiff4 = $this->__sumdiff(4);
-            if (PEAR::isError($sumdiff4)) {
-                return $sumdiff4;
-            }
+
             $this->_calculatedValues['kurtosis'] = ($sumdiff4 / ($count * pow($stDev, 4))) - 3;
         }
         return $this->_calculatedValues['kurtosis'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the median of a data set.
@@ -884,24 +948,28 @@ class Math_Stats {/*{{{*/
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the median value on success, a PEAR_Error object otherwise  
+     * @return  mixed   the median value on success, a PEAR_Error object otherwise
      * @see count()
      * @see calc()
      */
-    function median() {/*{{{*/
+    public function median()
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         if (!array_key_exists('median', $this->_calculatedValues)) {
-            if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
-                $arr =& $this->_dataExpanded;
+            if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
+                $arr = &$this->_dataExpanded;
             } else {
-                $arr =& $this->_data;
+                $arr = &$this->_data;
             }
-            $n = $this->count();
-            if (PEAR::isError($n)) {
+            try {
+                $n = $this->count();
+            } catch (\PEAR_Exception $e) {
                 return $n;
             }
+
             $h = intval($n / 2);
             if ($n % 2 == 0) {
                 $median = ($arr[$h] + $arr[$h - 1]) / 2;
@@ -911,7 +979,7 @@ class Math_Stats {/*{{{*/
             $this->_calculatedValues['median'] = $median;
         }
         return $this->_calculatedValues['median'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the mode of a data set.
@@ -920,38 +988,44 @@ class Math_Stats {/*{{{*/
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   an array of mode value on success, a PEAR_Error object otherwise    
+     * @return  mixed   an array of mode value on success, a PEAR_Error object otherwise
      * @see frequency()
      * @see calc()
      */
-    function mode() {/*{{{*/
+    public function mode()
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         if (!array_key_exists('mode', $this->_calculatedValues)) {
-            if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
+            if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
                 $arr = $this->_data;
             } else {
                 $arr = $this->frequency();
             }
             arsort($arr);
             $mcount = 1;
-            foreach ($arr as $val=>$freq) {
+            foreach ($arr as $val => $freq) {
                 if ($mcount == 1) {
                     $mode = array($val);
                     $mfreq = $freq;
                     $mcount++;
                     continue;
                 }
-                if ($mfreq == $freq)
+                if ($mfreq == $freq) {
                     $mode[] = $val;
-                if ($mfreq > $freq)
+                }
+
+                if ($mfreq > $freq) {
                     break;
+                }
+
             }
             $this->_calculatedValues['mode'] = $mode;
         }
         return $this->_calculatedValues['mode'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the midrange of a data set.
@@ -959,50 +1033,59 @@ class Math_Stats {/*{{{*/
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the midrange value on success, a PEAR_Error object otherwise    
+     * @return  mixed   the midrange value on success, a PEAR_Error object otherwise
      * @see min()
      * @see max()
      * @see calc()
      */
-    function midrange() {/*{{{*/
+    public function midrange()
+    {
+
         if (!array_key_exists('midrange', $this->_calculatedValues)) {
-            $min = $this->min();
-            if (PEAR::isError($min)) {
+            try {
+                $min = $this->min();
+                try {
+                    $max = $this->max();
+                } catch (\PEAR_Exception $e) {
+                    return $max;
+                }
+            } catch (\PEAR_Exception $e) {
                 return $min;
             }
-            $max = $this->max();
-            if (PEAR::isError($max)) {
-                return $max;
-            }
+
             $this->_calculatedValues['midrange'] = (($max + $min) / 2);
         }
         return $this->_calculatedValues['midrange'];
-    }/*}}}*/
-  
+    }
+
     /**
      * Calculates the geometrical mean of the data points in the set
      * Handles cummulative data sets correctly
      *
      * @access public
-     * @return mixed the geometrical mean value on success, a PEAR_Error object otherwise    
+     * @return mixed the geometrical mean value on success, a PEAR_Error object otherwise
      * @see calc()
      * @see product()
      * @see count()
      */
-    function geometricMean() {/*{{{*/
+    public function geometricMean()
+    {
+
         if (!array_key_exists('geometricMean', $this->_calculatedValues)) {
-            $count = $this->count();
-            if (PEAR::isError($count)) {
+            try {
+                $count = $this->count();
+            } catch (\PEAR_Exception $e) {
                 return $count;
             }
-            $prod = $this->product();
-            if (PEAR::isError($prod)) {
+            try {
+                $prod = $this->product();
+            } catch (\PEAR_Exception $e) {
                 return $prod;
             }
             if (is_array($prod)) {
                 $geomMean = 1.0;
-                foreach($prod as $val) {
-                    $geomMean *= pow($val, 1/$count);
+                foreach ($prod as $val) {
+                    $geomMean *= pow($val, 1 / $count);
                 }
                 $this->_calculatedValues['geometricMean'] = $geomMean;
             } else {
@@ -1010,46 +1093,49 @@ class Math_Stats {/*{{{*/
                     return 0.0;
                 }
                 if ($prod < 0) {
-                    return PEAR::raiseError('The product of the data set is negative, geometric mean undefined.');
+                    throw new \PEAR_Exception('The product of the data set is negative, geometric mean undefined.');
                 }
-                $this->_calculatedValues['geometricMean'] = pow($prod , 1 / $count);
+                $this->_calculatedValues['geometricMean'] = pow($prod, 1 / $count);
             }
         }
         return $this->_calculatedValues['geometricMean'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the harmonic mean of the data points in the set
      * Handles cummulative data sets correctly
      *
      * @access public
-     * @return mixed the harmonic mean value on success, a PEAR_Error object otherwise    
+     * @return mixed the harmonic mean value on success, a PEAR_Error object otherwise
      * @see calc()
      * @see count()
      */
-    function harmonicMean() {/*{{{*/
+    public function harmonicMean()
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         if (!array_key_exists('harmonicMean', $this->_calculatedValues)) {
-            $count = $this->count();
-            if (PEAR::isError($count)) {
+            try {
+                $count = $this->count();
+            } catch (\PEAR_Exception $e) {
                 return $count;
             }
             $invsum = 0.0;
-            if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
-                foreach($this->_data as $val=>$freq) {
+            if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
+                foreach ($this->_data as $val => $freq) {
                     if ($val == 0) {
-                        return PEAR::raiseError('cannot calculate a '.
-                                'harmonic mean with data values of zero.');
+                        throw new \PEAR_Exception('cannot calculate a ' .
+                            'harmonic mean with data values of zero.');
                     }
                     $invsum += $freq / $val;
                 }
             } else {
-                foreach($this->_data as $val) {
+                foreach ($this->_data as $val) {
                     if ($val == 0) {
-                        return PEAR::raiseError('cannot calculate a '.
-                                'harmonic mean with data values of zero.');
+                        throw new \PEAR_Exception('cannot calculate a ' .
+                            'harmonic mean with data values of zero.');
                     }
                     $invsum += 1 / $val;
                 }
@@ -1057,7 +1143,7 @@ class Math_Stats {/*{{{*/
             $this->_calculatedValues['harmonicMean'] = $count / $invsum;
         }
         return $this->_calculatedValues['harmonicMean'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the nth central moment (m{n}) of a data set.
@@ -1072,28 +1158,32 @@ class Math_Stats {/*{{{*/
      * @param integer $n moment to calculate
      * @return mixed the numeric value of the moment on success, PEAR_Error otherwise
      */
-    function sampleCentralMoment($n) {/*{{{*/
+    public function sampleCentralMoment($n)
+    {
+
         if (!is_int($n) || $n < 1) {
-            return PEAR::raiseError('moment must be a positive integer >= 1.');
+            throw new \PEAR_Exception('moment must be a positive integer >= 1.');
         }
-        
+
         if ($n == 1) {
             return 0;
         }
-        $count = $this->count();
-        if (PEAR::isError($count)) {
+        try {
+            $count = $this->count();
+        } catch (\PEAR_Exception $e) {
             return $count;
         }
         if ($count == 0) {
-            return PEAR::raiseError("Cannot calculate {$n}th sample moment, ".
-                    'there are zero data entries');
+            throw new \PEAR_Exception("Cannot calculate {$n}th sample moment, " .
+                'there are zero data entries');
         }
-        $sum = $this->__sumdiff($n);
-        if (PEAR::isError($sum)) {
+        try {
+            $sum = $this->__sumdiff($n);
+        } catch (\PEAR_Exception $e) {
             return $sum;
         }
         return ($sum / $count);
-    }/*}}}*/
+    }
 
     /**
      * Calculates the nth raw moment (m{n}) of a data set.
@@ -1103,63 +1193,71 @@ class Math_Stats {/*{{{*/
      *     m{n} = 1/N * SUM { xi^n }
      *
      * where: N = sample size, avg = sample mean.
-     * 
+     *
      * @access public
      * @param integer $n moment to calculate
      * @return mixed the numeric value of the moment on success, PEAR_Error otherwise
      */
-    function sampleRawMoment($n) {/*{{{*/
+    public function sampleRawMoment($n)
+    {
+
         if (!is_int($n) || $n < 1) {
-            return PEAR::raiseError('moment must be a positive integer >= 1.');
+            throw new \PEAR_Exception('moment must be a positive integer >= 1.');
         }
-        
-        $count = $this->count();
-        if (PEAR::isError($count)) {
+
+        try {
+            $count = $this->count();
+        } catch (\PEAR_Exception $e) {
             return $count;
         }
         if ($count == 0) {
-            return PEAR::raiseError("Cannot calculate {$n}th raw moment, ".
-                    'there are zero data entries.');
+            throw new \PEAR_Exception("Cannot calculate {$n}th raw moment, " .
+                'there are zero data entries.');
         }
-        $sum = $this->sumN($n);
-        if (PEAR::isError($sum)) {
+        try {
+            $sum = $this->sumN($n);
+        } catch (\PEAR_Exception $e) {
             return $sum;
         }
         return ($sum / $count);
-    }/*}}}*/
-
+    }
 
     /**
      * Calculates the coefficient of variation of a data set.
-     * The coefficient of variation measures the spread of a set of data 
+     * The coefficient of variation measures the spread of a set of data
      * as a proportion of its mean. It is often expressed as a percentage.
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   the coefficient of variation on success, a PEAR_Error object otherwise  
+     * @return  mixed   the coefficient of variation on success, a PEAR_Error object otherwise
      * @see stDev()
      * @see mean()
      * @see calc()
      */
-    function coeffOfVariation() {/*{{{*/
+    public function coeffOfVariation()
+    {
+
         if (!array_key_exists('coeffOfVariation', $this->_calculatedValues)) {
-            $mean = $this->mean();
-            if (PEAR::isError($mean)) {
+            try {
+                $mean = $this->mean();
+            } catch (\PEAR_Exception $e) {
                 return $mean;
             }
+
             if ($mean == 0.0) {
-                return PEAR::raiseError('cannot calculate the coefficient '.
-                        'of variation, mean of sample is zero');
+                throw new \PEAR_Exception('cannot calculate the coefficient ' .
+                    'of variation, mean of sample is zero');
             }
-            $stDev = $this->stDev();
-            if (PEAR::isError($stDev)) {
+            try {
+                $stDev = $this->stDev();
+            } catch (\PEAR_Exception $e) {
                 return $stDev;
             }
 
             $this->_calculatedValues['coeffOfVariation'] = $stDev / $mean;
         }
         return $this->_calculatedValues['coeffOfVariation'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the standard error of the mean.
@@ -1170,45 +1268,51 @@ class Math_Stats {/*{{{*/
      *
      * This formula does not assume a normal distribution, and shows
      * that the size of the standard error of the mean is inversely
-     * proportional to the square root of the sample size. 
+     * proportional to the square root of the sample size.
      *
      * @access  public
-     * @return  mixed   the standard error of the mean on success, a PEAR_Error object otherwise  
+     * @return  mixed   the standard error of the mean on success, a PEAR_Error object otherwise
      * @see stDev()
      * @see count()
      * @see calc()
      */
-    function stdErrorOfMean() {/*{{{*/
+    public function stdErrorOfMean()
+    {
+
         if (!array_key_exists('stdErrorOfMean', $this->_calculatedValues)) {
-            $count = $this->count();
-            if (PEAR::isError($count)) {
+            try {
+                $count = $this->count();
+            } catch (\PEAR_Exception $e) {
                 return $count;
             }
-            $stDev = $this->stDev();
-            if (PEAR::isError($stDev)) {
+            try {
+                $stDev = $this->stDev();
+            } catch (\PEAR_Exception $e) {
                 return $stDev;
             }
             $this->_calculatedValues['stdErrorOfMean'] = $stDev / sqrt($count);
         }
         return $this->_calculatedValues['stdErrorOfMean'];
-    }/*}}}*/
+    }
 
     /**
      * Calculates the value frequency table of a data set.
      * Handles cummulative data sets correctly
      *
      * @access  public
-     * @return  mixed   an associative array of value=>frequency items on success, a PEAR_Error object otherwise    
+     * @return  mixed   an associative array of value=>frequency items on success, a PEAR_Error object otherwise
      * @see min()
      * @see max()
      * @see calc()
      */
-    function frequency() {/*{{{*/
+    public function frequency()
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         if (!array_key_exists('frequency', $this->_calculatedValues)) {
-            if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
+            if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
                 $freq = $this->_data;
             } else {
                 $freq = array();
@@ -1223,7 +1327,7 @@ class Math_Stats {/*{{{*/
             $this->_calculatedValues['frequency'] = $freq;
         }
         return $this->_calculatedValues['frequency'];
-    }/*}}}*/
+    }
 
     /**
      * The quartiles are defined as the values that divide a sorted
@@ -1234,46 +1338,56 @@ class Math_Stats {/*{{{*/
      * @return mixed an associative array of quartiles on success, a PEAR_Error otherwise
      * @see percentile()
      */
-    function quartiles() {/*{{{*/
+    public function quartiles()
+    {
+
         if (!array_key_exists('quartiles', $this->_calculatedValues)) {
-            $q1 = $this->percentile(25);
-            if (PEAR::isError($q1)) {
+            try {
+                $q1 = $this->percentile(25);
+                try {
+                    $q2 = $this->percentile(50);
+                    try {
+                        $q3 = $this->percentile(75);
+                    } catch (\PEAR_Exception $e) {
+                        return $q3;
+                    }
+                } catch (\PEAR_Exception $e) {
+                    return $q2;
+                }
+
+            } catch (\PEAR_Exception $e) {
                 return $q1;
             }
-            $q2 = $this->percentile(50);
-            if (PEAR::isError($q2)) {
-                return $q2;
-            }
-            $q3 = $this->percentile(75);
-            if (PEAR::isError($q3)) {
-                return $q3;
-            }
-            $this->_calculatedValues['quartiles'] = array (
-                                        '25' => $q1,
-                                        '50' => $q2,
-                                        '75' => $q3
-                                        );
+
+            $this->_calculatedValues['quartiles'] = array(
+                '25' => $q1,
+                '50' => $q2,
+                '75' => $q3,
+            );
         }
         return $this->_calculatedValues['quartiles'];
-    }/*}}}*/
-    
+    }
+
     /**
-     * The interquartile mean is defined as the mean of the values left 
+     * The interquartile mean is defined as the mean of the values left
      * after discarding the lower 25% and top 25% ranked values, i.e.:
      *
      *  interquart mean = mean(<P(25),P(75)>)
      *
      *  where: P = percentile
-     * 
+     *
      * @todo need to double check the equation
      * @access public
      * @return mixed a numeric value on success, a PEAR_Error otherwise
      * @see quartiles()
      */
-    function interquartileMean() {/*{{{*/
+    public function interquartileMean()
+    {
+
         if (!array_key_exists('interquartileMean', $this->_calculatedValues)) {
-            $quart = $this->quartiles();
-            if (PEAR::isError($quart)) {
+            try {
+                $quart = $this->quartiles();
+            } catch (\PEAR_Exception $e) {
                 return $quart;
             }
             $q3 = $quart['75'];
@@ -1287,13 +1401,13 @@ class Math_Stats {/*{{{*/
                 }
             }
             if ($n == 0) {
-                return PEAR::raiseError('error calculating interquartile mean, '.
-                                        'empty interquartile range of values.');
+                throw new \PEAR_Exception('error calculating interquartile mean, ' .
+                    'empty interquartile range of values.');
             }
             $this->_calculatedValues['interquartileMean'] = $sum / $n;
         }
         return $this->_calculatedValues['interquartileMean'];
-    }/*}}}*/
+    }
 
     /**
      * The interquartile range is the distance between the 75th and 25th
@@ -1308,10 +1422,13 @@ class Math_Stats {/*{{{*/
      * @return mixed a numeric value on success, a PEAR_Error otherwise
      * @see quartiles()
      */
-    function interquartileRange() {/*{{{*/
+    public function interquartileRange()
+    {
+
         if (!array_key_exists('interquartileRange', $this->_calculatedValues)) {
-            $quart = $this->quartiles();
-            if (PEAR::isError($quart)) {
+            try {
+                $quart = $this->quartiles();
+            } catch (\PEAR_Exception $e) {
                 return $quart;
             }
             $q3 = $quart['75'];
@@ -1319,30 +1436,33 @@ class Math_Stats {/*{{{*/
             $this->_calculatedValues['interquartileRange'] = $q3 - $q1;
         }
         return $this->_calculatedValues['interquartileRange'];
-    }/*}}}*/
-    
+    }
+
     /**
      * The quartile deviation is half of the interquartile range value
      *
      *  quart dev = (P(75) - P(25)) / 2
      *
      *  where: P = percentile
-     *  
+     *
      * @access public
      * @return mixed a numeric value on success, a PEAR_Error otherwise
      * @see quartiles()
      * @see interquartileRange()
      */
-    function quartileDeviation() {/*{{{*/
+    public function quartileDeviation()
+    {
+
         if (!array_key_exists('quartileDeviation', $this->_calculatedValues)) {
-            $iqr = $this->interquartileRange();
-            if (PEAR::isError($iqr)) {
+            try {
+                $iqr = $this->interquartileRange();
+            } catch (\PEAR_Exception $e) {
                 return $iqr;
             }
             $this->_calculatedValues['quartileDeviation'] = $iqr / 2;
         }
         return $this->_calculatedValues['quartileDeviation'];
-    }/*}}}*/
+    }
 
     /**
      * The quartile variation coefficient is defined as follows:
@@ -1350,16 +1470,19 @@ class Math_Stats {/*{{{*/
      *  quart var coeff = 100 * (P(75) - P(25)) / (P(75) + P(25))
      *
      *  where: P = percentile
-     * 
+     *
      * @todo need to double check the equation
      * @access public
      * @return mixed a numeric value on success, a PEAR_Error otherwise
      * @see quartiles()
      */
-    function quartileVariationCoefficient() {/*{{{*/
+    public function quartileVariationCoefficient()
+    {
+
         if (!array_key_exists('quartileVariationCoefficient', $this->_calculatedValues)) {
-            $quart = $this->quartiles();
-            if (PEAR::isError($quart)) {
+            try {
+                $quart = $this->quartiles();
+            } catch (\PEAR_Exception $e) {
                 return $quart;
             }
             $q3 = $quart['75'];
@@ -1369,7 +1492,7 @@ class Math_Stats {/*{{{*/
             $this->_calculatedValues['quartileVariationCoefficient'] = 100 * $d / $s;
         }
         return $this->_calculatedValues['quartileVariationCoefficient'];
-    }/*}}}*/
+    }
 
     /**
      * The quartile skewness coefficient (also known as Bowley Skewness),
@@ -1378,33 +1501,36 @@ class Math_Stats {/*{{{*/
      *  quart skewness coeff = (P(25) - 2*P(50) + P(75)) / (P(75) - P(25))
      *
      *  where: P = percentile
-     * 
+     *
      * @todo need to double check the equation
      * @access public
      * @return mixed a numeric value on success, a PEAR_Error otherwise
      * @see quartiles()
      */
-    function quartileSkewnessCoefficient() {/*{{{*/
+    public function quartileSkewnessCoefficient()
+    {
+
         if (!array_key_exists('quartileSkewnessCoefficient', $this->_calculatedValues)) {
-            $quart = $this->quartiles();
-            if (PEAR::isError($quart)) {
+            try {
+                $quart = $this->quartiles();
+            } catch (\PEAR_Exception $e) {
                 return $quart;
             }
             $q3 = $quart['75'];
             $q2 = $quart['50'];
             $q1 = $quart['25'];
-            $d = $q3 - 2*$q2 + $q1;
+            $d = $q3 - 2 * $q2 + $q1;
             $s = $q3 - $q1;
             $this->_calculatedValues['quartileSkewnessCoefficient'] = $d / $s;
         }
         return $this->_calculatedValues['quartileSkewnessCoefficient'];
-    }/*}}}*/
+    }
 
     /**
      * The pth percentile is the value such that p% of the a sorted data set
      * is smaller than it, and (100 - p)% of the data is larger.
      *
-     * A quick algorithm to pick the appropriate value from a sorted data 
+     * A quick algorithm to pick the appropriate value from a sorted data
      * set is as follows:
      *
      * - Count the number of values: n
@@ -1424,15 +1550,18 @@ class Math_Stats {/*{{{*/
      * @see quartiles()
      * @see median()
      */
-    function percentile($p) {/*{{{*/
-        $count = $this->count();
-        if (PEAR::isError($count)) {
+    public function percentile($p)
+    {
+        try {
+            $count = $this->count();
+        } catch (\PEAR_Exception $e) {
             return $count;
         }
-        if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
-            $data =& $this->_dataExpanded;
+
+        if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
+            $data = &$this->_dataExpanded;
         } else {
-            $data =& $this->_data;
+            $data = &$this->_data;
         }
         $obsidx = $p * ($count + 1) / 100;
         if (intval($obsidx) == $obsidx) {
@@ -1446,13 +1575,13 @@ class Math_Stats {/*{{{*/
             $right = ceil($obsidx - 1);
             return ($data[$left] + $data[$right]) / 2;
         }
-    }/*}}}*/
+    }
 
     // private methods
 
     /**
      * Utility function to calculate: SUM { (xi - mean)^n }
-     * 
+     *
      * @access private
      * @param   numeric $power  the exponent
      * @param   optional    double   $mean   the data set mean value
@@ -1463,27 +1592,33 @@ class Math_Stats {/*{{{*/
      * @see skewness();
      * @see kurtosis();
      */
-    function __sumdiff($power, $mean=null) {/*{{{*/
+    public function __sumdiff($power, $mean = null)
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         if (is_null($mean)) {
-            $mean = $this->mean();
-            if (PEAR::isError($mean)) {
+            try {
+                $mean = $this->mean();
+            } catch (\PEAR_Exception $e) {
                 return $mean;
             }
+
         }
         $sdiff = 0;
-        if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
-            foreach ($this->_data as $val=>$freq) {
-                $sdiff += $freq * pow((double)($val - $mean), (double)$power);
+        if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
+            foreach ($this->_data as $val => $freq) {
+                $sdiff += $freq * pow((double) ($val - $mean), (double) $power);
             }
         } else {
-            foreach ($this->_data as $val)
-                $sdiff += pow((double)($val - $mean), (double)$power);
+            foreach ($this->_data as $val) {
+                $sdiff += pow((double) ($val - $mean), (double) $power);
+            }
+
         }
         return $sdiff;
-    }/*}}}*/
+    }
 
     /**
      * Utility function to calculate the variance with or without
@@ -1495,23 +1630,28 @@ class Math_Stats {/*{{{*/
      * @see variance()
      * @see varianceWithMean()
      */
-    function __calcVariance($mean = null) {/*{{{*/
+    public function __calcVariance($mean = null)
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
-        $sumdiff2 = $this->__sumdiff(2, $mean);
-        if (PEAR::isError($sumdiff2)) {
+        try {
+            $sumdiff2 = $this->__sumdiff(2, $mean);
+            try {
+                $count = $this->count();
+            } catch (\PEAR_Exception $e) {
+                return $count;
+            }
+        } catch (\PEAR_Exception $e) {
             return $sumdiff2;
         }
-        $count = $this->count();
-        if (PEAR::isError($count)) {
-            return $count;
-        }
+
         if ($count == 1) {
-            return PEAR::raiseError('cannot calculate variance of a singe data point');
+            throw new \PEAR_Exception('cannot calculate variance of a singe data point');
         }
-        return  ($sumdiff2 / ($count - 1));
-    }/*}}}*/
+        return ($sumdiff2 / ($count - 1));
+    }
 
     /**
      * Utility function to calculate the absolute deviation with or without
@@ -1523,20 +1663,25 @@ class Math_Stats {/*{{{*/
      * @see absDev()
      * @see absDevWithMean()
      */
-    function __calcAbsoluteDeviation($mean = null) {/*{{{*/
+    public function __calcAbsoluteDeviation($mean = null)
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
-        $count = $this->count();
-        if (PEAR::isError($count)) {
+        try {
+            $count = $this->count();
+            try {
+                $sumabsdev = $this->__sumabsdev($mean);
+            } catch (\PEAR_Exception $e) {
+                return $sumabsdev;
+            }
+        } catch (\PEAR_Exception $e) {
             return $count;
         }
-        $sumabsdev = $this->__sumabsdev($mean);
-        if (PEAR::isError($sumabsdev)) {
-            return $sumabsdev;
-        }
+
         return $sumabsdev / $count;
-    }/*}}}*/
+    }
 
     /**
      * Utility function to calculate: SUM { | xi - mean | }
@@ -1548,16 +1693,18 @@ class Math_Stats {/*{{{*/
      * @see absDev()
      * @see absDevWithMean()
      */
-    function __sumabsdev($mean=null) {/*{{{*/
+    public function __sumabsdev($mean = null)
+    {
+
         if ($this->_data == null) {
-            return PEAR::raiseError('data has not been set');
+            throw new \PEAR_Exception('data has not been set');
         }
         if (is_null($mean)) {
             $mean = $this->mean();
         }
         $sdev = 0;
-        if ($this->_dataOption == STATS_DATA_CUMMULATIVE) {
-            foreach ($this->_data as $val=>$freq) {
+        if ($this->_dataOption == self::STATS_DATA_CUMMULATIVE) {
+            foreach ($this->_data as $val => $freq) {
                 $sdev += $freq * abs($val - $mean);
             }
         } else {
@@ -1566,27 +1713,29 @@ class Math_Stats {/*{{{*/
             }
         }
         return $sdev;
-    }/*}}}*/
+    }
 
     /**
      * Utility function to format a PEAR_Error to be used by calc(),
      * calcBasic() and calcFull()
-     * 
+     *
      * @access private
      * @param mixed $v value to be formatted
-     * @param boolean $returnErrorObject whether the raw PEAR_Error (when true, default), 
+     * @param boolean $returnErrorObject whether the raw PEAR_Error (when true, default),
      *                  or only the error message will be returned (when false)
      * @return mixed if the value is a PEAR_Error object, and $useErrorObject
      *              is false, then a string with the error message will be returned,
      *              otherwise the value will not be modified and returned as passed.
      */
-    function __format($v, $useErrorObject=true) {/*{{{*/
-        if (PEAR::isError($v) && $useErrorObject == false) {
+    public function __format($v, $useErrorObject = true)
+    {
+
+        if (is_a($v, '\PEAR_Exception') && $useErrorObject == false) {
             return $v->getMessage();
         } else {
             return $v;
         }
-    }/*}}}*/
+    }
 
     /**
      * Utility function to validate the data and modify it
@@ -1594,20 +1743,22 @@ class Math_Stats {/*{{{*/
      *
      * @access  private
      * @return  mixed true on success, a PEAR_Error object otherwise
-     * 
+     *
      * @see setData()
      */
-    function _validate() {/*{{{*/
-        $cummulativeData = ($this->_dataOption == STATS_DATA_CUMMULATIVE);
-        foreach ($this->_data as $key=>$value) {
+    public function _validate()
+    {
+
+        $cummulativeData = ($this->_dataOption == self::STATS_DATA_CUMMULATIVE);
+        foreach ($this->_data as $key => $value) {
             $d = ($cummulativeData) ? $key : $value;
             $v = ($cummulativeData) ? $value : $key;
             if (!is_numeric($d)) {
                 switch ($this->_nullOption) {
-                    case STATS_IGNORE_NULL :
+                    case self::STATS_IGNORE_NULL:
                         unset($this->_data["$key"]);
                         break;
-                    case STATS_USE_NULL_AS_ZERO:
+                    case self::STATS_USE_NULL_AS_ZERO:
                         if ($cummulativeData) {
                             unset($this->_data["$key"]);
                             // TODO: shift up?
@@ -1619,9 +1770,9 @@ class Math_Stats {/*{{{*/
                             $this->_data[$key] = 0;
                         }
                         break;
-                    case STATS_REJECT_NULL :
+                    case self::STATS_REJECT_NULL:
                     default:
-                        return PEAR::raiseError('data rejected, contains NULL values');
+                        throw new \PEAR_Exception('data rejected, contains NULL values');
                         break;
                 }
             }
@@ -1636,35 +1787,33 @@ class Math_Stats {/*{{{*/
             // see php-src/ext/standard/array.c)
 
             //$array_pad_magic_limit = 1048576;
-            foreach ($this->_data as $val=>$freq) {
+            foreach ($this->_data as $val => $freq) {
                 // try an ugly kludge
-                for ($k=0; $k < $freq; $k++) {
+                for ($k = 0; $k < $freq; $k++) {
                     $this->_dataExpanded[] = $val;
                 }
                 /* the code below causes a core dump
                 $valArr = array_fill(0, $freq, $val);
                 $this->_dataExpanded = array_merge($this->_dataExpanded, $valArr);
-                */
+                 */
                 /* the code below gives incorrect values
-                // kludge to cover for array_pad's *features*
-                $newcount = count($this->_dataExpanded) + $freq;
-                while ($newcount > $array_pad_magic_limit) {
-                    $this->_dataExpanded = array_pad($this->_dataExpanded, $array_pad_magic_limit, $val);
-                    $newcount -= $array_pad_magic_limit;
-                }
-                $this->_dataExpanded = array_pad($this->_dataExpanded, $newcount, $val);
-                */
+            // kludge to cover for array_pad's *features*
+            $newcount = count($this->_dataExpanded) + $freq;
+            while ($newcount > $array_pad_magic_limit) {
+            $this->_dataExpanded = array_pad($this->_dataExpanded, $array_pad_magic_limit, $val);
+            $newcount -= $array_pad_magic_limit;
+            }
+            $this->_dataExpanded = array_pad($this->_dataExpanded, $newcount, $val);
+             */
             }
             //sort($this->_dataExpanded);
         } else {
             sort($this->_data);
         }
         return true;
-    }/*}}}*/
+    }
 
-}/*}}}*/
+}
 
 // vim: ts=4:sw=4:et:
 // vim6: fdl=1: fdm=marker:
-
-?>

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,28 @@
 {
-    "authors": [
-        {
-            "email": "jmcastagnetto@php.net",
-            "name": "Jesus M. Castagnetto",
-            "role": "Lead"
-        }
-    ],
-    "autoload": {
-        "psr-0": {
-            "Math": "./"
-        }
-    },
-    "description": "More info available on: http://pear.php.net/package/Math_Stats",
-    "include-path": [
-        "./"
-    ],
-    "license": "PHP",
-    "name": "pear/math_stats",
-    "support": {
-        "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Math_Stats",
-        "source": "https://github.com/pear/Math_Stats"
-    },
-    "type": "library",
-    "require": {
-        "pear/pear_exception": "*"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "*"
-    }
+	"authors": [{
+		"email": "jmcastagnetto@php.net",
+		"name": "Jesus M. Castagnetto",
+		"role": "Lead"
+	}],
+	"autoload": {
+		"psr-0": {
+			"PEAR\\Math": "./"
+		}
+	},
+	"description": "More info available on: http://pear.php.net/package/Math_Stats",
+
+	"license": "PHP",
+	"name": "pear/math_stats",
+	"support": {
+		"issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Math_Stats",
+		"source": "https://github.com/pear/Math_Stats"
+	},
+	"type": "library",
+	"require": {
+		"php": ">=5.3.3",
+		"pear/pear_exception": "*"
+	},
+	"require-dev": {
+		"phpunit/phpunit": "*"
+	}
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,19 @@
+<phpunit bootstrap="./tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+>
+    <testsuite name="Math_Stats">
+        <directory suffix=".php">./tests</directory>
+    </testsuite>
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+                <exclude>
+                    <directory>./vendor</directory>
+                    <directory>./tests</directory>
+                </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/AllTests.php
+++ b/tests/AllTests.php
@@ -4,8 +4,6 @@ if (!defined('PHPUnit_MAIN_METHOD')) {
     define('PHPUnit_MAIN_METHOD', 'Math_Stats_AllTests::main');
 }
 
-require_once 'PHPUnit/TextUI/TestRunner.php';
-
 require_once 'Math_StatsTest.php';
 
 class Math_Stats_AllTests

--- a/tests/Math_StatsTest.php
+++ b/tests/Math_StatsTest.php
@@ -25,10 +25,6 @@
  * @package Math_Stats
  */
 
-require_once 'PHPUnit/Framework/TestCase.php';
-require_once 'Math/Stats.php';
-require_once 'test_Math_Stats_instance_methods-data.php';
-
 define('__PRECISION', 12);
 define('__DELTA', pow(10, -1 * (__PRECISION - 4)));
 
@@ -39,55 +35,71 @@ ini_set('precision', __PRECISION);
  * Unit test class Math_Stats
  *
  */
-class Math_StatsTest extends PHPUnit_Framework_TestCase {/*{{{*/
+class Math_StatsTest extends PHPUnit_Framework_TestCase
+{
+/*{{{*/
 
-    var $s1;
-    var $s2a;
-    var $s2b;
-    var $s3;
-    var $s4a;
-    var $s4b;
+    public $s1;
+    public $s2a;
+    public $s2b;
+    public $s3;
+    public $s4a;
+    public $s4b;
 
     // simple data set
-    var $data1 = array (2,2.3,4.5,2,2,3.2,5.3,3,4,5,1,6);
+    public $data1 = array(2, 2.3, 4.5, 2, 2, 3.2, 5.3, 3, 4, 5, 1, 6);
     // data set with nulls
-    var $data2 = array (1.1650,null, "foo",0.6268, 0.6268, 0.0751, 0.3516, -0.6965);
+    public $data2 = array(1.1650, null, "foo", 0.6268, 0.6268, 0.0751, 0.3516, -0.6965);
     // cummulative data set
-    var $data3 = array("3"=>4, "2.333"=>5, "1.22"=>6, "0.5"=>3, "0.9"=>2, "2.4"=>7);
+    public $data3 = array("3" => 4, "2.333" => 5, "1.22" => 6, "0.5" => 3, "0.9" => 2, "2.4" => 7);
     // cummulative data set with nulls
-    var $data4 = array("3"=>4, "plink"=>2, "bar is not foo"=>6, "0.5"=>3, "0.9"=>2, "2.4"=>7);
+    public $data4 = array("3" => 4, "plink" => 2, "bar is not foo" => 6, "0.5" => 3, "0.9" => 2, "2.4" => 7);
 
-    function Math_Stats_UnitTest($name) {/*{{{*/
+    public function Math_Stats_UnitTest($name)
+    {
+/*{{{*/
         $this->PHPUnit_TestCase($name);
-    }/*}}}*/
+    }
 
-    function setUp() {/*{{{*/
+/*}}}*/
+
+    public function setUp()
+    {
+/*{{{*/
         // simple data sets
-        $this->s1 = new Math_Stats(STATS_REJECT_NULL);
+        $this->s1 = new \PEAR\Math\Stats(\PEAR\Math\Stats::STATS_REJECT_NULL);
         $this->s1->setData($this->data1);
-        $this->s2a = new Math_Stats(STATS_IGNORE_NULL);
+        $this->s2a = new \PEAR\Math\Stats(\PEAR\Math\Stats::STATS_IGNORE_NULL);
         $this->s2a->setData($this->data2);
-        $this->s2b = new Math_Stats(STATS_USE_NULL_AS_ZERO);
+        $this->s2b = new \PEAR\Math\Stats(\PEAR\Math\Stats::STATS_USE_NULL_AS_ZERO);
         $this->s2b->setData($this->data2);
         // cummulative data sets
-        $this->s3 = new Math_Stats(STATS_REJECT_NULL);
-        $this->s3->setData($this->data3, STATS_DATA_CUMMULATIVE);
-        $this->s4a = new Math_Stats(STATS_IGNORE_NULL);
-        $this->s4a->setData($this->data4, STATS_DATA_CUMMULATIVE);
-        $this->s4b = new Math_Stats(STATS_USE_NULL_AS_ZERO);
-        $this->s4b->setData($this->data4, STATS_DATA_CUMMULATIVE);
-    }/*}}}*/
+        $this->s3 = new \PEAR\Math\Stats(\PEAR\Math\Stats::STATS_REJECT_NULL);
+        $this->s3->setData($this->data3, \PEAR\Math\Stats::STATS_DATA_CUMMULATIVE);
+        $this->s4a = new \PEAR\Math\Stats(\PEAR\Math\Stats::STATS_IGNORE_NULL);
+        $this->s4a->setData($this->data4, \PEAR\Math\Stats::STATS_DATA_CUMMULATIVE);
+        $this->s4b = new \PEAR\Math\Stats(\PEAR\Math\Stats::STATS_USE_NULL_AS_ZERO);
+        $this->s4b->setData($this->data4, \PEAR\Math\Stats::STATS_DATA_CUMMULATIVE);
+    }
 
-    function tearDown() {/*{{{*/
+/*}}}*/
+
+    public function tearDown()
+    {
+/*{{{*/
         unset($this->s1);
         unset($this->s2a);
         unset($this->s2b);
         unset($this->s3);
         unset($this->s4a);
         unset($this->s4b);
-    }/*}}}*/
+    }
 
-    function testGetData() {/*{{{*/
+/*}}}*/
+
+    public function testGetData()
+    {
+/*{{{*/
         $this->assertEquals($GLOBALS['testGetData_out1'], $this->formatArray($this->s1->getData()));
         $this->assertEquals($GLOBALS['testGetData_out2'], $this->formatArray($this->s2a->getData()));
         $this->assertEquals($GLOBALS['testGetData_out3'], $this->formatArray($this->s2b->getData()));
@@ -95,669 +107,821 @@ class Math_StatsTest extends PHPUnit_Framework_TestCase {/*{{{*/
         $this->assertEquals($GLOBALS['testGetData_out5'], $this->formatArray($this->s4a->getData()));
         $this->assertEquals($GLOBALS['testGetData_out6'], $this->formatArray($this->s4a->getData(true)));
         $this->assertEquals($GLOBALS['testGetData_out7'], $this->formatArray($this->s4b->getData()));
-	}/*}}}*/
+    }
 
-    function testCalcBasic() {/*{{{*/
+/*}}}*/
+
+    public function testCalcBasic()
+    {
+/*{{{*/
         $this->assertEquals($GLOBALS['testCalcBasic_out1'],
-                            $this->formatArray($this->s1->calcBasic(false)));
+            $this->formatArray($this->s1->calcBasic(false)));
         $this->assertEquals($GLOBALS['testCalcBasic_out2'],
-                            $this->formatArray($this->s2a->calcBasic(false)));
+            $this->formatArray($this->s2a->calcBasic(false)));
         $this->assertEquals($GLOBALS['testCalcBasic_out3'],
-                            $this->formatArray($this->s2b->calcBasic(false)));
+            $this->formatArray($this->s2b->calcBasic(false)));
         $this->assertEquals($GLOBALS['testCalcBasic_out4'],
-                            $this->formatArray($this->s3->calcBasic(false)));
+            $this->formatArray($this->s3->calcBasic(false)));
         $this->assertEquals($GLOBALS['testCalcBasic_out5'],
-                            $this->formatArray($this->s4a->calcBasic(false)));
+            $this->formatArray($this->s4a->calcBasic(false)));
         $this->assertEquals($GLOBALS['testCalcBasic_out6'],
-                            $this->formatArray($this->s4b->calcBasic(false)));
-	}/*}}}*/
+            $this->formatArray($this->s4b->calcBasic(false)));
+    }
 
-    function testCalcFull() {/*{{{*/
+/*}}}*/
+
+    public function testCalcFull()
+    {
+/*{{{*/
         $this->assertEquals($GLOBALS['testCalcFull_out1'],
-                            $this->formatArray($this->s1->calcFull(false)));
-        $this->assertEquals($GLOBALS['testCalcFull_out2'],
-                            $this->formatArray($this->s2a->calcFull(false)));
+            $this->formatArray($this->s1->calcFull(false)));
+
+        $this->setExpectedException('PEAR_Exception', 'The product of the data set is negative, geometric mean undefined.');
+        $this->formatArray($this->s2a->calcFull(false));
+
         $this->assertEquals($GLOBALS['testCalcFull_out3'],
-                            $this->formatArray($this->s2b->calcFull(false)));
+            $this->formatArray($this->s2b->calcFull(false)));
+
         $this->assertEquals($GLOBALS['testCalcFull_out4'],
-                            $this->formatArray($this->s3->calcFull(false)));
+            $this->formatArray($this->s3->calcFull(false)));
+
         $this->assertEquals($GLOBALS['testCalcFull_out5'],
-                            $this->formatArray($this->s4a->calcFull(false)));
+            $this->formatArray($this->s4a->calcFull(false)));
+
         $this->assertEquals($GLOBALS['testCalcFull_out6'],
-                            $this->formatArray($this->s4b->calcFull(false)));
-	}/*}}}*/
+            $this->formatArray($this->s4b->calcFull(false)));
+    }
 
-    function testMin() {/*{{{*/
+/*}}}*/
+
+    public function testMin()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(1),
-							$this->formatNumber($this->s1->min()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->min()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.6965),
-							$this->formatNumber($this->s2a->min()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->min()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.6965),
-							$this->formatNumber($this->s2b->min()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->min()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.5),
-							$this->formatNumber($this->s3->min()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->min()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.5),
-							$this->formatNumber($this->s4a->min()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->min()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0),
-							$this->formatNumber($this->s4b->min()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->min()),
+            '', __DELTA);
+    }
 
-    function testMax() {/*{{{*/
+/*}}}*/
+
+    public function testMax()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(6),
-							$this->formatNumber($this->s1->max()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->max()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.165),
-							$this->formatNumber($this->s2a->max()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->max()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.165),
-							$this->formatNumber($this->s2b->max()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->max()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(3),
-							$this->formatNumber($this->s3->max()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->max()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(3),
-							$this->formatNumber($this->s4a->max()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->max()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(3),
-							$this->formatNumber($this->s4b->max()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->max()),
+            '', __DELTA);
+    }
 
-    function testSum() {/*{{{*/
+/*}}}*/
+
+    public function testSum()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(40.3),
-							$this->formatNumber($this->s1->sum()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->sum()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.1488),
-							$this->formatNumber($this->s2a->sum()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->sum()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.1488),
-							$this->formatNumber($this->s2b->sum()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->sum()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(51.085),
-							$this->formatNumber($this->s3->sum()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->sum()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(32.1),
-							$this->formatNumber($this->s4a->sum()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->sum()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(32.1),
-							$this->formatNumber($this->s4b->sum()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->sum()),
+            '', __DELTA);
+    }
 
-    function testSum2() {/*{{{*/
+/*}}}*/
+
+    public function testSum2()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(162.87),
-							$this->formatNumber($this->s1->sum2()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->sum2()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.7573563),
-							$this->formatNumber($this->s2a->sum2()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->sum2()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.7573563),
-							$this->formatNumber($this->s2b->sum2()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->sum2()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(114.834845),
-							$this->formatNumber($this->s3->sum2()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->sum2()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(78.69),
-							$this->formatNumber($this->s4a->sum2()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->sum2()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(78.69),
-							$this->formatNumber($this->s4b->sum2()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->sum2()),
+            '', __DELTA);
+    }
 
-    function testSumN() {/*{{{*/
+/*}}}*/
+
+    public function testSumN()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(741.937),
-							$this->formatNumber($this->s1->sumN(3)),
-							'', __DELTA);
+            $this->formatNumber($this->s1->sumN(3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.77968786139),
-							$this->formatNumber($this->s2a->sumN(3)),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->sumN(3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.40141456571),
-							$this->formatNumber($this->s2b->sumN(4)),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->sumN(4)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(280.987388185),
-							$this->formatNumber($this->s3->sumN(3)),
-							'', __DELTA);
+            $this->formatNumber($this->s3->sumN(3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(206.601),
-							$this->formatNumber($this->s4a->sumN(3)),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->sumN(3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(557.7429),
-							$this->formatNumber($this->s4b->sumN(4)),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->sumN(4)),
+            '', __DELTA);
+    }
 
-    function testProduct() {/*{{{*/
+/*}}}*/
+
+    public function testProduct()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(505543.68),
-							$this->formatNumber($this->s1->product()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->product()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.00841770739124),
-							$this->formatNumber($this->s2a->product()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->product()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0),
-							$this->formatNumber($this->s2b->product()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->product()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(46478.287296),
-							$this->formatNumber($this->s3->product()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->product()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(544.32),
-							$this->formatNumber($this->s4a->product()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->product()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0),
-							$this->formatNumber($this->s4b->product()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->product()),
+            '', __DELTA);
+    }
 
-    function testProductN() {/*{{{*/
+/*}}}*/
+
+    public function testProductN()
+    {
+/*{{{*/
         $this->assertEquals('255574412388',
-							(string)$this->s1->productN(2),
-							'', __DELTA);
+            (string) $this->s1->productN(2),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(7.08577977246E-05),
-							$this->formatNumber($this->s2a->productN(2)),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->productN(2)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0),
-							$this->formatNumber($this->s2b->productN(3)),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->productN(3)),
+            '', __DELTA);
         $this->assertEquals('428617.299597',
-							(string)$this->s3->productN(2),
-							'', __DELTA);
+            (string) $this->s3->productN(2),
+            '', __DELTA);
         $this->assertEquals('5714.053632',
-							(string)$this->s4a->productN(3),
-							'', __DELTA);
+            (string) $this->s4a->productN(3),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0),
-							$this->formatNumber($this->s4b->productN(2)),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->productN(2)),
+            '', __DELTA);
+    }
 
-    function testCount() {/*{{{*/
+/*}}}*/
+
+    public function testCount()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(12),
-							$this->formatNumber($this->s1->count()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->count()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(6),
-							$this->formatNumber($this->s2a->count()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->count()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(8),
-							$this->formatNumber($this->s2b->count()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->count()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(27),
-							$this->formatNumber($this->s3->count()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->count()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(16),
-							$this->formatNumber($this->s4a->count()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->count()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(24),
-							$this->formatNumber($this->s4b->count()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->count()),
+            '', __DELTA);
+    }
 
-    function testMean() {/*{{{*/
+/*}}}*/
+
+    public function testMean()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(3.35833333333),
-							$this->formatNumber($this->s1->mean()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->mean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.358133333333),
-							$this->formatNumber($this->s2a->mean()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->mean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.2686),
-							$this->formatNumber($this->s2b->mean()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->mean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.89203703704),
-							$this->formatNumber($this->s3->mean()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->mean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.00625),
-							$this->formatNumber($this->s4a->mean()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->mean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.3375),
-							$this->formatNumber($this->s4b->mean()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->mean()),
+            '', __DELTA);
+    }
 
-    function testRange() {/*{{{*/
+/*}}}*/
+
+    public function testRange()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(5),
-							$this->formatNumber($this->s1->range()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->range()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.8615),
-							$this->formatNumber($this->s2a->range()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->range()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.8615),
-							$this->formatNumber($this->s2b->range()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->range()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.5),
-							$this->formatNumber($this->s3->range()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->range()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.5),
-							$this->formatNumber($this->s4a->range()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->range()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(3),
-							$this->formatNumber($this->s4b->range()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->range()),
+            '', __DELTA);
+    }
 
-    function testVariance() {/*{{{*/
+/*}}}*/
+
+    public function testVariance()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(2.50265151515),
-							$this->formatNumber($this->s1->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.397559878667),
-							$this->formatNumber($this->s2a->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.311455517143),
-							$this->formatNumber($this->s2b->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.699235883191),
-							$this->formatNumber($this->s3->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.952625),
-							$this->formatNumber($this->s4a->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.55461956522),
-							$this->formatNumber($this->s4b->variance()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->variance()),
+            '', __DELTA);
+    }
 
-    function testStDev() {/*{{{*/
+/*}}}*/
+
+    public function testStDev()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(1.58197709059),
-							$this->formatNumber($this->s1->stDev()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->stDev()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.630523495729),
-							$this->formatNumber($this->s2a->stDev()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->stDev()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.558081998583),
-							$this->formatNumber($this->s2b->stDev()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->stDev()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.836203254712),
-							$this->formatNumber($this->s3->stDev()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->stDev()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.976025102136),
-							$this->formatNumber($this->s4a->stDev()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->stDev()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.24684384155),
-							$this->formatNumber($this->s4b->stDev()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->stDev()),
+            '', __DELTA);
+    }
 
-    function testVarianceWithMean() {/*{{{*/
+/*}}}*/
+
+    public function testVarianceWithMean()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(2.50454545455),
-							$this->formatNumber($this->s1->varianceWithMean(3.4)),
-							'', __DELTA);
+            $this->formatNumber($this->s1->varianceWithMean(3.4)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.39966326),
-							$this->formatNumber($this->s2a->varianceWithMean(0.4)),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->varianceWithMean(0.4)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.312582328571),
-							$this->formatNumber($this->s2b->varianceWithMean(0.3)),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->varianceWithMean(0.3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.699301730769),
-							$this->formatNumber($this->s3->varianceWithMean(1.9)),
-							'', __DELTA);
+            $this->formatNumber($this->s3->varianceWithMean(1.9)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.952666666667),
-							$this->formatNumber($this->s4a->varianceWithMean(2.0)),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->varianceWithMean(2.0)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.55869565217),
-							$this->formatNumber($this->s4b->varianceWithMean(1.4)),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->varianceWithMean(1.4)),
+            '', __DELTA);
+    }
 
-    function testStDevWithMean() {/*{{{*/
+/*}}}*/
+
+    public function testStDevWithMean()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(1.58257557625),
-							$this->formatNumber($this->s1->stDevWithMean(3.4)),
-							'', __DELTA);
+            $this->formatNumber($this->s1->stDevWithMean(3.4)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.632189259637),
-							$this->formatNumber($this->s2a->stDevWithMean(0.4)),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->stDevWithMean(0.4)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.559090626439),
-							$this->formatNumber($this->s2b->stDevWithMean(0.3)),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->stDevWithMean(0.3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.836242626735),
-							$this->formatNumber($this->s3->stDevWithMean(1.9)),
-							'', __DELTA);
+            $this->formatNumber($this->s3->stDevWithMean(1.9)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.976046446982),
-							$this->formatNumber($this->s4a->stDevWithMean(2.0)),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->stDevWithMean(2.0)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.24847733346),
-							$this->formatNumber($this->s4b->stDevWithMean(1.4)),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->stDevWithMean(1.4)),
+            '', __DELTA);
+    }
 
-    function testAbsDev() {/*{{{*/
+/*}}}*/
+
+    public function testAbsDev()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(2.50265151515),
-							$this->formatNumber($this->s1->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.39755987867),
-							$this->formatNumber($this->s2a->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.31145551714),
-							$this->formatNumber($this->s2b->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.69923588319),
-							$this->formatNumber($this->s3->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.952625),
-							$this->formatNumber($this->s4a->variance()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->variance()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.55461956522),
-							$this->formatNumber($this->s4b->variance()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->variance()),
+            '', __DELTA);
+    }
 
-    function testAbsDevWithMean() {/*{{{*/
+/*}}}*/
+
+    public function testAbsDevWithMean()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(1.34166666667),
-							$this->formatNumber($this->s1->absDevWithMean(3.4)),
-							'', __DELTA);
+            $this->formatNumber($this->s1->absDevWithMean(3.4)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.448066666667),
-							$this->formatNumber($this->s2a->absDevWithMean(0.4)),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->absDevWithMean(0.4)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.42395),
-							$this->formatNumber($this->s2b->absDevWithMean(0.3)),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->absDevWithMean(0.3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.753518518519),
-							$this->formatNumber($this->s3->absDevWithMean(1.9)),
-							'', __DELTA);
+            $this->formatNumber($this->s3->absDevWithMean(1.9)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.84375),
-							$this->formatNumber($this->s4a->absDevWithMean(2.0)),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->absDevWithMean(2.0)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.17916666667),
-							$this->formatNumber($this->s4b->absDevWithMean(1.4)),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->absDevWithMean(1.4)),
+            '', __DELTA);
+    }
 
-    function testSkewness() {/*{{{*/
+/*}}}*/
+
+    public function testSkewness()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(0.211767803758),
-							$this->formatNumber($this->s1->skewness()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->skewness()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.419944986921),
-							$this->formatNumber($this->s2a->skewness()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->skewness()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.0950243805522),
-							$this->formatNumber($this->s2b->skewness()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->skewness()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.321743512221),
-							$this->formatNumber($this->s3->skewness()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->skewness()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.578555878286),
-							$this->formatNumber($this->s4a->skewness()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->skewness()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.122636601767),
-							$this->formatNumber($this->s4b->skewness()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->skewness()),
+            '', __DELTA);
+    }
 
-    function testKurtosis() {/*{{{*/
+/*}}}*/
+
+    public function testKurtosis()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(-1.47708896609),
-							$this->formatNumber($this->s1->kurtosis()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->kurtosis()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-1.23078655976),
-							$this->formatNumber($this->s2a->kurtosis()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->kurtosis()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.992375284912),
-							$this->formatNumber($this->s2b->kurtosis()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->kurtosis()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-1.4009978017),
-							$this->formatNumber($this->s3->kurtosis()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->kurtosis()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-1.4499405466),
-							$this->formatNumber($this->s4a->kurtosis()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->kurtosis()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-1.8513180639),
-							$this->formatNumber($this->s4b->kurtosis()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->kurtosis()),
+            '', __DELTA);
+    }
 
-    function testMedian() {/*{{{*/
+/*}}}*/
+
+    public function testMedian()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(3.1),
-							$this->formatNumber($this->s1->median()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->median()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.4892),
-							$this->formatNumber($this->s2a->median()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->median()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.21335),
-							$this->formatNumber($this->s2b->median()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->median()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.333),
-							$this->formatNumber($this->s3->median()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->median()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.4),
-							$this->formatNumber($this->s4a->median()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->median()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.9),
-							$this->formatNumber($this->s4b->median()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->median()),
+            '', __DELTA);
+    }
 
-    function testMode() {/*{{{*/
+/*}}}*/
+
+    public function testMode()
+    {
+/*{{{*/
         $this->assertEquals($GLOBALS['testMode_out1'], $this->formatArray($this->s1->mode()));
         $this->assertEquals($GLOBALS['testMode_out2'], $this->formatArray($this->s2a->mode()));
         $this->assertEquals($GLOBALS['testMode_out3'], $this->formatArray($this->s2b->mode()));
         $this->assertEquals($GLOBALS['testMode_out4'], $this->formatArray($this->s3->mode()));
         $this->assertEquals($GLOBALS['testMode_out5'], $this->formatArray($this->s4a->mode()));
         $this->assertEquals($GLOBALS['testMode_out6'], $this->formatArray($this->s4b->mode()));
-	}/*}}}*/
+    }
 
-    function testMidrange() {/*{{{*/
+/*}}}*/
+
+    public function testMidrange()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(3.5),
-							$this->formatNumber($this->s1->midrange()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->midrange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.23425),
-							$this->formatNumber($this->s2a->midrange()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->midrange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.23425),
-							$this->formatNumber($this->s2b->midrange()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->midrange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.75),
-							$this->formatNumber($this->s3->midrange()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->midrange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.75),
-							$this->formatNumber($this->s4a->midrange()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->midrange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.5),
-							$this->formatNumber($this->s4b->midrange()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->midrange()),
+            '', __DELTA);
+    }
 
-    function testGeometricMean() {/*{{{*/
+/*}}}*/
+
+    public function testGeometricMean()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(2.98753652642),
-							$this->formatNumber($this->s1->geometricMean()),
-							'', __DELTA);
-        $this->assertTrue(is_a($this->s2a->geometricMean(),'PEAR_Error'));
+            $this->formatNumber($this->s1->geometricMean()),
+            '', __DELTA);
+        $this->setExpectedException('PEAR_Exception', 'The product of the data set is negative, geometric mean undefined.');
+        $this->s2a->geometricMean();
+
         $this->assertEquals($this->formatNumber(0),
-							$this->formatNumber($this->s2b->geometricMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->geometricMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.48888486575),
-							$this->formatNumber($this->s3->geometricMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->geometricMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.48248699844),
-							$this->formatNumber($this->s4a->geometricMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->geometricMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0),
-							$this->formatNumber($this->s4b->geometricMean()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->geometricMean()),
+            '', __DELTA);
+    }
 
-    function testHarmonicMean() {/*{{{*/
+/*}}}*/
+
+    public function testHarmonicMean()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(2.98753652642),
-							$this->formatNumber($this->s1->geometricMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->geometricMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.319605399284),
-							$this->formatNumber($this->s2a->harmonicMean()),
-							'', __DELTA);
-        $this->assertTrue(is_a($this->s2b->harmonicMean(),'PEAR_Error'));
+            $this->formatNumber($this->s2a->harmonicMean()),
+            '', __DELTA);
+
+        $this->setExpectedException('PEAR_Exception', 'cannot calculate a harmonic mean with data values of zero.');
+        $this->s2b->harmonicMean();
+
         $this->assertEquals($this->formatNumber(1.38224654591),
-							$this->formatNumber($this->s3->harmonicMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->harmonicMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.28285077951),
-							$this->formatNumber($this->s4a->harmonicMean()),
-							'', __DELTA);
-        $this->assertTrue(is_a($this->s4b->harmonicMean(),'PEAR_Error'));
-	}/*}}}*/
+            $this->formatNumber($this->s4a->harmonicMean()),
+            '', __DELTA);
 
-    function testSampleCentralMoment() {/*{{{*/
+        $this->setExpectedException('PEAR_Exception', 'cannot calculate a harmonic mean with data values of zero.');
+        $this->s4b->harmonicMean();
+    }
+
+/*}}}*/
+
+    public function testSampleCentralMoment()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(2.29409722222),
-							$this->formatNumber($this->s1->sampleCentralMoment(2)),
-							'', __DELTA);
+            $this->formatNumber($this->s1->sampleCentralMoment(2)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.331299898889),
-							$this->formatNumber($this->s2a->sampleCentralMoment(2)),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->sampleCentralMoment(2)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.0165169209322),
-							$this->formatNumber($this->s2b->sampleCentralMoment(3)),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->sampleCentralMoment(3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.188124500214),
-							$this->formatNumber($this->s3->sampleCentralMoment(3)),
-							'', __DELTA);
+            $this->formatNumber($this->s3->sampleCentralMoment(3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.8930859375),
-							$this->formatNumber($this->s4a->sampleCentralMoment(2)),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->sampleCentralMoment(2)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.48984375),
-							$this->formatNumber($this->s4b->sampleCentralMoment(2)),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->sampleCentralMoment(2)),
+            '', __DELTA);
+    }
 
-    function testSampleRawMoment() {/*{{{*/
+/*}}}*/
+
+    public function testSampleRawMoment()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(13.5725),
-							$this->formatNumber($this->s1->sampleRawMoment(2)),
-							'', __DELTA);
+            $this->formatNumber($this->s1->sampleRawMoment(2)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.459559383333),
-							$this->formatNumber($this->s2a->sampleRawMoment(2)),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->sampleRawMoment(2)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.222460982673),
-							$this->formatNumber($this->s2b->sampleRawMoment(3)),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->sampleRawMoment(3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(10.4069403031),
-							$this->formatNumber($this->s3->sampleRawMoment(3)),
-							'', __DELTA);
+            $this->formatNumber($this->s3->sampleRawMoment(3)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(4.918125),
-							$this->formatNumber($this->s4a->sampleRawMoment(2)),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->sampleRawMoment(2)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(3.27875),
-							$this->formatNumber($this->s4b->sampleRawMoment(2)),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->sampleRawMoment(2)),
+            '', __DELTA);
+    }
 
-    function testCoeffOfVariation() {/*{{{*/
+/*}}}*/
+
+    public function testCoeffOfVariation()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(0.471060175858),
-							$this->formatNumber($this->s1->coeffOfVariation()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->coeffOfVariation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.76058310423),
-							$this->formatNumber($this->s2a->coeffOfVariation()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->coeffOfVariation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.07774385176),
-							$this->formatNumber($this->s2b->coeffOfVariation()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->coeffOfVariation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.441959241993),
-							$this->formatNumber($this->s3->coeffOfVariation()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->coeffOfVariation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.486492262747),
-							$this->formatNumber($this->s4a->coeffOfVariation()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->coeffOfVariation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.932219694619),
-							$this->formatNumber($this->s4b->coeffOfVariation()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->coeffOfVariation()),
+            '', __DELTA);
+    }
 
-    function testStdErrorOfMean() {/*{{{*/
+/*}}}*/
+
+    public function testStdErrorOfMean()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(0.456677449552),
-							$this->formatNumber($this->s1->stdErrorOfMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->stdErrorOfMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.257410139229),
-							$this->formatNumber($this->s2a->stdErrorOfMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->stdErrorOfMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.197311782828),
-							$this->formatNumber($this->s2b->stdErrorOfMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->stdErrorOfMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.160927391402),
-							$this->formatNumber($this->s3->stdErrorOfMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->stdErrorOfMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.244006275534),
-							$this->formatNumber($this->s4a->stdErrorOfMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->stdErrorOfMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.254510933395),
-							$this->formatNumber($this->s4b->stdErrorOfMean()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->stdErrorOfMean()),
+            '', __DELTA);
+    }
 
-    function testFrequency() {/*{{{*/
+/*}}}*/
+
+    public function testFrequency()
+    {
+/*{{{*/
         $this->assertEquals($GLOBALS['testFrequency_out1'], $this->formatArray($this->s1->frequency()));
         $this->assertEquals($GLOBALS['testFrequency_out2'], $this->formatArray($this->s2a->frequency()));
         $this->assertEquals($GLOBALS['testFrequency_out3'], $this->formatArray($this->s2b->frequency()));
         $this->assertEquals($GLOBALS['testFrequency_out4'], $this->formatArray($this->s3->frequency()));
         $this->assertEquals($GLOBALS['testFrequency_out5'], $this->formatArray($this->s4a->frequency()));
         $this->assertEquals($GLOBALS['testFrequency_out6'], $this->formatArray($this->s4b->frequency()));
-    }/*}}}*/
+    }
 
-    function testQuartiles() {/*{{{*/
+/*}}}*/
+
+    public function testQuartiles()
+    {
+/*{{{*/
         $this->assertEquals($GLOBALS['testQuartiles_out1'], $this->formatArray($this->s1->quartiles()));
         $this->assertEquals($GLOBALS['testQuartiles_out2'], $this->formatArray($this->s2a->quartiles()));
         $this->assertEquals($GLOBALS['testQuartiles_out3'], $this->formatArray($this->s2b->quartiles()));
         $this->assertEquals($GLOBALS['testQuartiles_out4'], $this->formatArray($this->s3->quartiles()));
         $this->assertEquals($GLOBALS['testQuartiles_out5'], $this->formatArray($this->s4a->quartiles()));
         $this->assertEquals($GLOBALS['testQuartiles_out6'], $this->formatArray($this->s4b->quartiles()));
-    }/*}}}*/
+    }
 
-    function testInterQuartileMean() {/*{{{*/
+/*}}}*/
+
+    public function testInterQuartileMean()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(2.875),
-							$this->formatNumber($this->s1->interquartileMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->interquartileMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.420075),
-							$this->formatNumber($this->s2a->interquartileMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->interquartileMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.28005),
-							$this->formatNumber($this->s2b->interquartileMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->interquartileMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.98805555556),
-							$this->formatNumber($this->s3->interquartileMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->interquartileMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.06666666667),
-							$this->formatNumber($this->s4a->interquartileMean()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->interquartileMean()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.005),
-							$this->formatNumber($this->s4b->interquartileMean()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->interquartileMean()),
+            '', __DELTA);
+    }
 
-    function testInterquartileRange() {/*{{{*/
+/*}}}*/
+
+    public function testInterquartileRange()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(2.75),
-							$this->formatNumber($this->s1->interquartileRange()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->interquartileRange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.2066),
-							$this->formatNumber($this->s2a->interquartileRange()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->interquartileRange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.6268),
-							$this->formatNumber($this->s2b->interquartileRange()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->interquartileRange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.18),
-							$this->formatNumber($this->s3->interquartileRange()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->interquartileRange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.8),
-							$this->formatNumber($this->s4a->interquartileRange()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->interquartileRange()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.4),
-							$this->formatNumber($this->s4b->interquartileRange()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->interquartileRange()),
+            '', __DELTA);
+    }
 
-    function testQuartileDeviation() {/*{{{*/
+/*}}}*/
+
+    public function testQuartileDeviation()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(1.375),
-							$this->formatNumber($this->s1->quartileDeviation()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->quartileDeviation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.6033),
-							$this->formatNumber($this->s2a->quartileDeviation()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->quartileDeviation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.3134),
-							$this->formatNumber($this->s2b->quartileDeviation()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->quartileDeviation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.59),
-							$this->formatNumber($this->s3->quartileDeviation()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->quartileDeviation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.9),
-							$this->formatNumber($this->s4a->quartileDeviation()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->quartileDeviation()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.2),
-							$this->formatNumber($this->s4b->quartileDeviation()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->quartileDeviation()),
+            '', __DELTA);
+    }
 
-    function testQuartileVariationCoefficient() {/*{{{*/
+/*}}}*/
+
+    public function testQuartileVariationCoefficient()
+    {
+/*{{{*/
         /*
         echo "quartileVariationCoefficient\n";
         echo $this->s1->quartileVariationCoefficient() ."\n";
@@ -766,28 +930,32 @@ class Math_StatsTest extends PHPUnit_Framework_TestCase {/*{{{*/
         echo $this->s3->quartileVariationCoefficient() ."\n";
         echo $this->s4a->quartileVariationCoefficient()."\n";
         echo $this->s4b->quartileVariationCoefficient()."\n";
-        */
+         */
         $this->assertEquals($this->formatNumber(40.7407407407),
-							$this->formatNumber($this->s1->quartileVariationCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->quartileVariationCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(206.185919344),
-							$this->formatNumber($this->s2a->quartileVariationCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->quartileVariationCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(100),
-							$this->formatNumber($this->s2b->quartileVariationCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->quartileVariationCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(32.5966850829),
-							$this->formatNumber($this->s3->quartileVariationCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->quartileVariationCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(50),
-							$this->formatNumber($this->s4a->quartileVariationCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->quartileVariationCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(100),
-							$this->formatNumber($this->s4b->quartileVariationCoefficient()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->quartileVariationCoefficient()),
+            '', __DELTA);
+    }
 
-    function testQuartileSkewnessCoefficient() {/*{{{*/
+/*}}}*/
+
+    public function testQuartileSkewnessCoefficient()
+    {
+/*{{{*/
         /*
         echo "quartileSkewnessCoefficient\n";
         echo $this->s1->quartileSkewnessCoefficient() ."\n";
@@ -796,90 +964,115 @@ class Math_StatsTest extends PHPUnit_Framework_TestCase {/*{{{*/
         echo $this->s3->quartileSkewnessCoefficient() ."\n";
         echo $this->s4a->quartileSkewnessCoefficient()."\n";
         echo $this->s4b->quartileSkewnessCoefficient()."\n";
-        */
+         */
         $this->assertEquals($this->formatNumber(0.2),
-							$this->formatNumber($this->s1->quartileSkewnessCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s1->quartileSkewnessCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.3258743577),
-							$this->formatNumber($this->s2a->quartileSkewnessCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->quartileSkewnessCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.31924058711),
-							$this->formatNumber($this->s2b->quartileSkewnessCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->quartileSkewnessCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.88644067797),
-							$this->formatNumber($this->s3->quartileSkewnessCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s3->quartileSkewnessCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(-0.66666666667),
-							$this->formatNumber($this->s4a->quartileSkewnessCoefficient()),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->quartileSkewnessCoefficient()),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.25),
-							$this->formatNumber($this->s4b->quartileSkewnessCoefficient()),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->quartileSkewnessCoefficient()),
+            '', __DELTA);
+    }
 
-    function testPercentile() {/*{{{*/
+/*}}}*/
+
+    public function testPercentile()
+    {
+/*{{{*/
         $this->assertEquals($this->formatNumber(2),
-							$this->formatNumber($this->s1->percentile(25)),
-							'', __DELTA);
+            $this->formatNumber($this->s1->percentile(25)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.6268),
-							$this->formatNumber($this->s2a->percentile(60)),
-							'', __DELTA);
+            $this->formatNumber($this->s2a->percentile(60)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(0.8959),
-							$this->formatNumber($this->s2b->percentile(80)),
-							'', __DELTA);
+            $this->formatNumber($this->s2b->percentile(80)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(1.22),
-							$this->formatNumber($this->s3->percentile(25)),
-							'', __DELTA);
+            $this->formatNumber($this->s3->percentile(25)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.4),
-							$this->formatNumber($this->s4a->percentile(60)),
-							'', __DELTA);
+            $this->formatNumber($this->s4a->percentile(60)),
+            '', __DELTA);
         $this->assertEquals($this->formatNumber(2.4),
-							$this->formatNumber($this->s4b->percentile(80)),
-							'', __DELTA);
-	}/*}}}*/
+            $this->formatNumber($this->s4b->percentile(80)),
+            '', __DELTA);
+    }
 
-    function testStudentize() {/*{{{*/
+/*}}}*/
+
+    public function testStudentize()
+    {
+/*{{{*/
         $this->s1->studentize();
-        $this->assertEquals($GLOBALS['testStudentize_out1'],
-                            $this->formatArray($this->s1->getData()));
+
+        $this->setExpectedException('PEAR_Exception', 'The product of the data set is negative, geometric mean undefined.');
+        $this->formatArray($this->s1->getData());
+
         $this->assertEquals($GLOBALS['testStudentize_out2'],
-                            $this->formatArray($this->s1->calcFull(false)));
+            $this->formatArray($this->s1->calcFull(false)));
         $this->s3->studentize();
         $this->assertEquals($GLOBALS['testStudentize_out3'],
-                            $this->formatArray($this->s3->getData()));
+            $this->formatArray($this->s3->getData()));
         $this->assertEquals($GLOBALS['testStudentize_out4'],
-                            $this->formatArray($this->s3->calcFull(false)));
-    }/*}}}*/
+            $this->formatArray($this->s3->calcFull(false)));
+    }
 
-    function testCenter() {/*{{{*/
+/*}}}*/
+
+    public function testCenter()
+    {
+/*{{{*/
         $this->s1->center();
         $this->assertEquals($GLOBALS['testCenter_out1'],
-                            $this->formatArray($this->s1->getData()));
-        $this->assertEquals($GLOBALS['testCenter_out2'],
-                            $this->formatArray($this->s1->calcFull(false)));
+            $this->formatArray($this->s1->getData()));
+
+        $this->setExpectedException('PEAR_Exception', 'The product of the data set is negative, geometric mean undefined.');
+        $this->formatArray($this->s1->calcFull(false));
+
         $this->s3->center();
         $this->assertEquals($GLOBALS['testCenter_out3'],
-                            $this->formatArray($this->s3->getData()));
+            $this->formatArray($this->s3->getData()));
         $this->assertEquals($GLOBALS['testCenter_out4'],
-                            $this->formatArray($this->s3->calcFull(false)));
-    }/*}}}*/
+            $this->formatArray($this->s3->calcFull(false)));
+    }
 
-    function formatNumber($n) {/*{{{*/
-        return (float) sprintf('%.'.(__PRECISION - 1).'f', $n);
-    }/*}}}*/
+/*}}}*/
 
-    function formatArray($arr,$spcs=0) {/*{{{*/
+    public function formatNumber($n)
+    {
+/*{{{*/
+        return (float) sprintf('%.' . (__PRECISION - 1) . 'f', $n);
+    }
+
+/*}}}*/
+
+    public function formatArray($arr, $spcs = 0)
+    {
+/*{{{*/
         $out = '';
-        foreach ($arr as $key=>$val) {
-            $out .= str_repeat(" ",$spcs)."[$key : ";
+        foreach ($arr as $key => $val) {
+            $out .= str_repeat(" ", $spcs) . "[$key : ";
             if (is_array($val)) {
-                $out .= "\n".$this->formatArray($val, ($spcs + 1))."]\n";
+                $out .= "\n" . $this->formatArray($val, ($spcs + 1)) . "]\n";
             } else {
-                $out .= $val."]\n";
+                $out .= $val . "]\n";
             }
         }
         return $out;
-    }/*}}}*/
+    }
 
-}/*}}}*/
+/*}}}*/
 
+} /*}}}*/

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+ini_set('display_errors', 1);
+error_reporting(E_ALL);
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This Pull Request adds proper vendor and package namespacing to comply with PSR-0, thus fixing the usage of composer's autoloader (which was broken until now). This involved, also, moving the lib inside proper folder structure.

The public constant DEFINES have been encapsulated in class consts. 

The usage of PEAR::isError has been thoroughtly replaced by PEAR_Exception, and the tests have been modified accordingly.

I added phpunit.xml.dist and /tests/bootstrap.php to streamline the running of tests.

Every use of include, include_once, require and require_once have been removed to rely in autoloading only.
